### PR TITLE
Override the keras backend env variable if not set

### DIFF
--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -184,7 +184,7 @@ class KerasModel(BaseModel, GradientMixin):
 
     def __init__(self, weights, arch=None, custom_objects=None, backend=None):
         self.backend = backend
-        if self.backend is not None:
+        if self.backend is not None and 'KERAS_BACKEND' not in os.environ:
             logger.info("Using Keras backend: {0}".format(self.backend))
             os.environ['KERAS_BACKEND'] = self.backend
         import keras


### PR DESCRIPTION
this will allow the user to override the backend setting in the model.yaml file by setting the env variable before