### PR TITLE
Unicode fix

### DIFF
--- a/kipoi/postprocessing/variant_effects/utils/generic.py
+++ b/kipoi/postprocessing/variant_effects/utils/generic.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import sys
 import abc
 import copy
 import logging

--- a/kipoi/postprocessing/variant_effects/utils/generic.py
+++ b/kipoi/postprocessing/variant_effects/utils/generic.py
@@ -168,7 +168,10 @@ def convert_record(input_record, pyvcf_reader):
         for el in list(info_obj):
             out_str_elms.append(u"{0}={1}".format(*el))
         if len(out_str_elms) > 0:
-            return pyvcf_reader._parse_info(u";".join(out_str_elms).encode("ascii", "ignore"))
+            if sys.version_info[0] < 3:
+                return pyvcf_reader._parse_info(u";".join(out_str_elms).encode("ascii", "ignore"))
+            else:
+                return pyvcf_reader._parse_info(u";".join(out_str_elms))
         else:
             return {}
 


### PR DESCRIPTION
@Avsecz, the last unicode related fix breaks python3. The quick hack in this PR should handle it more gracefully.  In the mean time, maybe using the "six" (python compatibility lib for 2 and 3)  or remove python2.7 dependence eventually is the way to go