### PR TITLE
Enabled models to be installed by referring to a wildcard

### DIFF
--- a/kipoi/cli/parser_utils.py
+++ b/kipoi/cli/parser_utils.py
@@ -52,11 +52,14 @@ def add_dataloader(parser, with_args=True):
 # Multiple models/dataloaders
 def add_env_args(parser, source="kipoi"):
     parser.add_argument('model', nargs="+",
-                        help='Model name(s). You can use <source>::<model> to use models from different sources')
+                        help='Model name(s). You can use <source>::<model> to use models from different sources. \n'
+                        '<model> can also refer to a model-group - e.g. if you specify MaxEntScan then the dependencies\n'
+                        'for MaxEntScan/5prime and MaxEntScan/3prime will be installed')
     add_source(parser, default=source)
     parser.add_argument('--dataloader', default=[], nargs="+",
                         help="Dataloader name(s). If not specified, the model's default " +
-                        "Dataloader will be used. You can use <source>::<dataloader> to use dataloaders from different sources")
+                        "Dataloader will be used. You can use <source>::<dataloader> to use dataloaders from different sources\n"
+                        "As for the --model tag, you can specify whole dataloader groups.")
     parser.add_argument("--vep", action="store_true",
                         help="Include also the dependencies for variant effect prediction")
     parser.add_argument("--gpu", action="store_true",

--- a/tests/test_23_kipoi_env.py
+++ b/tests/test_23_kipoi_env.py
@@ -3,7 +3,7 @@
 import subprocess
 import os
 from kipoi.utils import read_yaml
-from kipoi.cli.env import get_env_name, export_env
+from kipoi.cli.env import get_env_name, export_env, list_subcomponents, merge_deps
 
 
 def test_env_name():
@@ -105,3 +105,12 @@ def test_export_multiple(tmpdir):
     del env_dict2['name']
 
     assert env_dict != env_dict2
+
+
+def test_list_submodules():
+    assert list_subcomponents("MaxEntScan", "kipoi", "model") == ["MaxEntScan/3prime", "MaxEntScan/5prime"]
+    assert list_subcomponents("Basenji", "kipoi", "model") == ["Basenji"]
+
+
+def test_deps():
+    assert merge_deps(["MaxEntScan"]) == merge_deps(["MaxEntScan/5prime"])

--- a/tests/test_23_kipoi_env.py
+++ b/tests/test_23_kipoi_env.py
@@ -108,8 +108,8 @@ def test_export_multiple(tmpdir):
 
 
 def test_list_submodules():
-    assert list_subcomponents("MaxEntScan", "kipoi", "model") == ["MaxEntScan/3prime", "MaxEntScan/5prime"]
-    assert list_subcomponents("Basenji", "kipoi", "model") == ["Basenji"]
+    assert set(list_subcomponents("MaxEntScan", "kipoi", "model")) == {"MaxEntScan/3prime", "MaxEntScan/5prime"}
+    assert set(list_subcomponents("Basenji", "kipoi", "model")) == {"Basenji"}
 
 
 def test_deps():


### PR DESCRIPTION
Enables to specify: `kipoi env create MaxEntScan`. This will merge the dependencies for all submodels (`MaxEntScan/5prime` and `MaxEntScan/3prime` in this case)