### PR TITLE
Unify loading

### DIFF
--- a/example/models/extended_coda/dataloader.yaml
+++ b/example/models/extended_coda/dataloader.yaml
@@ -1,5 +1,5 @@
 type: BatchGenerator
-defined_as: dataloader.py::extractor
+defined_as: dataloader.extractor
 args:
     intervals_file:
         doc: "tsv file with `chrom start end`"

--- a/example/models/extended_coda/model.yaml
+++ b/example/models/extended_coda/model.yaml
@@ -1,4 +1,4 @@
-type: keras
+defined_as: kipoi.model.KerasModel
 args:
     weights: model_files/keras2/model.h5
     backend: tensorflow

--- a/example/models/iris_model_template/dataloader.yaml
+++ b/example/models/iris_model_template/dataloader.yaml
@@ -1,5 +1,4 @@
-type: Dataset
-defined_as: dataloader.py::MyDataset
+defined_as: dataloader.MyDataset
 args:
     features_file:
         doc: >

--- a/example/models/iris_tensorflow/dataloader.yaml
+++ b/example/models/iris_tensorflow/dataloader.yaml
@@ -1,5 +1,4 @@
-type: Dataset
-defined_as: dataloader.py::MyDataset
+defined_as: dataloader.MyDataset
 args:
     features_file:
         doc: >

--- a/example/models/iris_tensorflow/model.yaml
+++ b/example/models/iris_tensorflow/model.yaml
@@ -1,4 +1,4 @@
-type: tensorflow
+defined_as: kipoi.model.TensorFlowModel
 args:
     input_nodes:
       features: inputs  # input = dictionary of np.arrays

--- a/example/models/kipoi_dataloader_decorator/dataloader.py
+++ b/example/models/kipoi_dataloader_decorator/dataloader.py
@@ -38,6 +38,16 @@ class MyDataset(Dataset):
               url: https://github.com/kipoi/kipoi/raw/57734d716b8dedaffe460855e7cfe8f37ec2d48d/example/models/sklearn_iris/example_files/targets.csv
               md5: 54e058d31d05897836302cd6961212a1
             optional: True
+        x_transformer:
+            doc: input_transformer
+            default:
+              url: https://github.com/kipoi/kipoi/raw/57734d716b8dedaffe460855e7cfe8f37ec2d48d/example/models/sklearn_iris/dataloader_files/x_transformer.pkl
+              md5: bc1bf3c61c418b2d07506a7d0521a893
+        y_transformer:
+            doc: input_transformer
+            default:
+              url: https://github.com/kipoi/kipoi/raw/57734d716b8dedaffe460855e7cfe8f37ec2d48d/example/models/sklearn_iris/dataloader_files/y_transformer.pkl
+              md5: 7332d50fd461c49ac6ce24c194abbbd3
         dummy:
             doc: dummy argument
             example: 5
@@ -66,17 +76,15 @@ class MyDataset(Dataset):
                 doc: Just an example metadata column
     """
 
-    def __init__(self, features_file, targets_file=None, dummy=None):
+    def __init__(self, features_file, targets_file=None, x_transformer=None, y_transformer=None, dummy=None):
         self.features_file = features_file
         self.targets_file = targets_file
         self.dummy = dummy
 
-        base_url = "https://github.com/kipoi/kipoi/raw/57734d716b8dedaffe460855e7cfe8f37ec2d48d/example/models/sklearn_iris/dataloader_files"
-        outdir = os.path.abspath(os.path.join(this_path, "downloaded/dataloader_files"))
-        if not os.path.exists(outdir):
-            os.makedirs(outdir)
-        self.y_transformer = read_pickle(get_file(os.path.join(outdir, "y_transformer.pkl"), origin=base_url + '/y_transformer.pkl'))
-        self.x_transformer = read_pickle(get_file(os.path.join(outdir, "x_transformer.pkl"), origin=base_url + '/x_transformer.pkl'))
+        assert x_transformer is not None
+        self.x_transformer = read_pickle(x_transformer)
+        assert y_transformer is not None
+        self.y_transformer = read_pickle(y_transformer)
 
         self.features = pd.read_csv(features_file)
         if targets_file is not None:

--- a/example/models/non_bedinput_model/dataloader.yaml
+++ b/example/models/non_bedinput_model/dataloader.yaml
@@ -1,5 +1,4 @@
-type: Dataset
-defined_as: dataloader.py::SeqDistDataset
+defined_as: dataloader.SeqDistDataset
 args:
   # TODO - should we use some special file-names?
     # if any of the arguments is numeric, the type specification is mandatory

--- a/example/models/pyt/dataloader.yaml
+++ b/example/models/pyt/dataloader.yaml
@@ -1,5 +1,4 @@
-type: Dataset
-defined_as: dataloader.py::SeqDataset
+defined_as: dataloader.SeqDataset
 args:
   intervals_file:
     doc: bed3 file with `chrom start end id score strand`

--- a/example/models/pyt/model.yaml
+++ b/example/models/pyt/model.yaml
@@ -1,4 +1,4 @@
-type: pytorch
+defined_as: kipoi.model.PyTorchModel
 args:
     file: model_files/pyt.py
     build_fn: get_model

--- a/example/models/rbp/dataloader.yaml
+++ b/example/models/rbp/dataloader.yaml
@@ -1,5 +1,4 @@
-type: Dataset
-defined_as: dataloader.py::SeqDistDataset
+defined_as: dataloader.SeqDistDataset
 args:
   # TODO - should we use some special file-names?
     # if any of the arguments is numeric, the type specification is mandatory

--- a/example/models/rbp/model.yaml
+++ b/example/models/rbp/model.yaml
@@ -1,4 +1,4 @@
-type: keras
+defined_as: kipoi.model.KerasModel
 args:
     arch: model_files/model.json
     weights:

--- a/example/models/sklearn_iris/dataloader.yaml
+++ b/example/models/sklearn_iris/dataloader.yaml
@@ -1,5 +1,4 @@
-type: Dataset
-defined_as: dataloader.py::MyDataset
+defined_as: dataloader.MyDataset
 args:
     features_file:
         doc: >

--- a/example/models/sklearn_iris/model.yaml
+++ b/example/models/sklearn_iris/model.yaml
@@ -1,4 +1,4 @@
-type: sklearn
+defined_as: kipoi.model.SklearnModel
 args:
     pkl_file: model_files/sklearn_model.pkl
     predict_method: predict_proba

--- a/example/models/tal1_model/dataloader.yaml
+++ b/example/models/tal1_model/dataloader.yaml
@@ -1,5 +1,4 @@
-type: Dataset
-defined_as: dataloader.py::SeqDataset
+defined_as: dataloader.SeqDataset
 args:
   intervals_file:
     doc: bed3 file with `chrom start end id score strand`

--- a/example/models/var_seqlen_model/dataloader.yaml
+++ b/example/models/var_seqlen_model/dataloader.yaml
@@ -1,5 +1,4 @@
-type: Dataset
-defined_as: dataloader.py::SeqDistDataset
+defined_as: dataloader.SeqDistDataset
 args:
   # TODO - should we use some special file-names?
     # if any of the arguments is numeric, the type specification is mandatory

--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from collections import OrderedDict
 import sys
 import os
 import yaml
 import kipoi  # for .config module
-from .utils import load_module, cd, merge_dicts, read_pickle, override_default_kwargs
+from .utils import load_module, cd, merge_dicts, read_pickle, override_default_kwargs, load_obj, inherits_from, infer_parent_class
 import abc
 import six
 import numpy as np
@@ -150,18 +151,40 @@ def get_model(model, source="kipoi", with_dataloader=True):
                 path = md.args[k].get_file(os.path.join(output_dir, fname))
                 md.args[k] = path
 
-        if md.type == 'custom':
-            Mod = load_model_custom(**md.args)
-            assert issubclass(Mod, BaseModel)  # it should inherit from Model
-            mod = Mod()
-        elif md.type in AVAILABLE_MODELS:
-            # TODO - this doesn't seem to work
-            mod = AVAILABLE_MODELS[md.type](**md.args)
+        if md.type is not None:
+            # old API
+            if md.type == 'custom':
+                Mod = load_model_custom(**md.args)
+                assert issubclass(Mod, BaseModel)  # it should inherit from Model
+                mod = Mod()
+            elif md.type in AVAILABLE_MODELS:
+                # TODO - this doesn't seem to work
+                mod = AVAILABLE_MODELS[md.type](**md.args)
+            else:
+                raise ValueError("Unsupported model type: {0}. " +
+                                 "Model type needs to be one of: {1}".
+                                 format(md.type,
+                                        ['custom'] + list(AVAILABLE_MODELS.keys())))
         else:
-            raise ValueError("Unsupported model type: {0}. " +
-                             "Model type needs to be one of: {1}".
-                             format(md.type,
-                                    ['custom'] + list(AVAILABLE_MODELS.keys())))
+            # new API
+            try:
+                Mod = load_obj(md.defined_as)
+            except ImportError:
+                if md.defined_as.startswith("kipoi.model."):
+                    # user tried importing some of the available models
+                    logger.error("{} is not a valid kipoi model. Available models are: {}\n".format(
+                        md.defined_as,
+                        ", ".join(["kipoi.model." + str(AVAILABLE_MODELS[k].__name__) for k in AVAILABLE_MODELS])
+                    ))
+                raise ImportError("Unable to import {}".format(md.defined_as))
+            if not inherits_from(Mod, BaseModel):
+                raise ValueError("Model {} needs to inherit from kipoi.model.BaseModel".format(md.defined_as))
+            mod = Mod(**md.args)
+            for k, v in six.iteritems(AVAILABLE_MODELS):
+                if isinstance(mod, v):
+                    md.type = k
+            if md.type is None:
+                md.type = 'custom'
 
     # populate the returned class
     mod.type = md.type
@@ -235,14 +258,14 @@ class LayerActivationMixin():
     @abc.abstractmethod
     def predict_activation_on_batch(self, x, layer, pre_nonlinearity=False):
         """
-        Get predictions based on layer output. 
+        Get predictions based on layer output.
 
         Arguments:
             x: model inputs from dataloader batch
             layer: layer identifier / name. can be integer or string.
             pre_nonlinearity: Assure that output is returned from before the non-linearity. This feature does
             not have to be implemented always (not possible). If not implemented and set to True either raise
-            Error or at least warn! 
+            Error or at least warn!
         """
         raise NotImplementedError
 
@@ -737,7 +760,7 @@ pt_type_conversions = {pre + k: v for pre in ["torch.", "torch.cuda."] for k, v 
 
 
 class PyTorchModel(BaseModel, GradientMixin, LayerActivationMixin):
-    """Loads a pytorch model. 
+    """Loads a pytorch model.
 
     """
 
@@ -749,14 +772,14 @@ class PyTorchModel(BaseModel, GradientMixin, LayerActivationMixin):
         `weights`: Path to the where the weights are stored (may also contain model architecture, see below)
         `gen_fn`: Either callable or path to callable that returns a pytorch model object. If `weights` is not None
         then the model weights will be loaded from that file, otherwise it is assumed that the weights are already set
-        after execution of `gen_fn()` or the function defined in `gen_fn`.  
+        after execution of `gen_fn()` or the function defined in `gen_fn`.
 
         Models can be loaded in 2 ways:
         If the model was saved:
 
         * `torch.save(model, ...)` then the model will be loaded by calling `torch.load(weights)`
         * `torch.save(model.state_dict(), ...)` then another callable has to be passed to arch which returns the
-        `model` object, on then `model.load_state_dict(torch.load(weights))` will then be called. 
+        `model` object, on then `model.load_state_dict(torch.load(weights))` will then be called.
 
         Where `weights` is the parameter of this function.
         Partly based on: https://stackoverflow.com/questions/42703500/best-way-to-save-a-trained-model-in-pytorch
@@ -1054,7 +1077,7 @@ class PyTorchModel(BaseModel, GradientMixin, LayerActivationMixin):
     def _register_fwd_hook(self, layer):
         """
         Install a forward hook on the given layer index
-        Returns a PytorchFwdHook object that contains a 
+        Returns a PytorchFwdHook object that contains a
         """
         fwd_hook_obj = PyTorchFwdHook()
         removable_hook_obj = layer.register_forward_hook(fwd_hook_obj.run_forward_hook)
@@ -1126,8 +1149,8 @@ class PyTorchModel(BaseModel, GradientMixin, LayerActivationMixin):
             avg_func: String name of averaging function to be applied across filters in layer `layer`
             layer: layer from which backwards the gradient should be calculated
             final_layer: Use the final (classification) layer as `layer`
-            selected_fwd_node: None or integer. If a layer is re-used models may support that the gradient is 
-            calculated only with respect to one of the incoming edges / nodes. 
+            selected_fwd_node: None or integer. If a layer is re-used models may support that the gradient is
+            calculated only with respect to one of the incoming edges / nodes.
             pre_nonlinearity: Try to use the layer output prior to activation (will not always be possible in an
             automatic way)
         """
@@ -1513,7 +1536,7 @@ class TensorFlowModel(BaseModel, GradientMixin, LayerActivationMixin):
 
     def predict_activation_on_batch(self, x, layer, pre_nonlinearity=False):
         """
-        Get predictions based on layer output. 
+        Get predictions based on layer output.
 
         Arguments:
             x: model inputs from dataloader batch
@@ -1526,8 +1549,8 @@ class TensorFlowModel(BaseModel, GradientMixin, LayerActivationMixin):
                              feed_dict=merge_dicts(feed_dict, self.const_feed_dict))
 
 
-AVAILABLE_MODELS = {"keras": KerasModel,
-                    "pytorch": PyTorchModel,
-                    "sklearn": SklearnModel,
-                    "tensorflow": TensorFlowModel}
+AVAILABLE_MODELS = OrderedDict([("keras", KerasModel),
+                                ("pytorch", PyTorchModel),
+                                ("sklearn", SklearnModel),
+                                ("tensorflow", TensorFlowModel)])
 # "custom": load_model_custom}

--- a/kipoi/specs.py
+++ b/kipoi/specs.py
@@ -831,10 +831,10 @@ def example_kwargs(dl_args, cache_path=None):
 class DataLoaderDescription(RelatedLoadSaveMixin):
     """Class representation of dataloader.yaml
     """
-    type = related.StringField()
     defined_as = related.StringField()
     args = related.MappingField(DataLoaderArgument, "name")
     output_schema = related.ChildField(DataLoaderSchema)
+    type = related.StringField(required=False)
     info = related.ChildField(Info, default=Info(), required=False)
     dependencies = related.ChildField(Dependencies, default=Dependencies(), required=False)
     path = related.StringField(required=False)

--- a/kipoi/specs.py
+++ b/kipoi/specs.py
@@ -760,10 +760,11 @@ class DataLoaderImport(RelatedConfigMixin):
 class ModelDescription(RelatedLoadSaveMixin):
     """Class representation of model.yaml
     """
-    type = related.StringField()
     args = related.ChildField(dict)
     info = related.ChildField(ModelInfo)
     schema = related.ChildField(ModelSchema)
+    defined_as = related.StringField(required=False)
+    type = related.StringField(required=False)
     default_dataloader = AnyField(default='.', required=False)
     postprocessing = related.ChildField(dict, default=OrderedDict(), required=False)
     dependencies = related.ChildField(Dependencies,
@@ -773,6 +774,8 @@ class ModelDescription(RelatedLoadSaveMixin):
     # TODO - add after loading validation for the arguments class?
 
     def __attrs_post_init__(self):
+        if self.defined_as is None and self.type is None:
+            raise ValueError("Either defined_as or type need to be specified")
         # load additional objects
         for k in self.postprocessing:
             k_observed = k

--- a/kipoi/utils.py
+++ b/kipoi/utils.py
@@ -44,9 +44,11 @@ def load_obj(obj_import):
 
     with add_sys_path(os.getcwd()):
         module_name, obj_name = obj_import.rsplit(".", 1)
+        if module_name in sys.modules:
+            # make sure this module hasn't been loaded before
+            del sys.modules[module_name]
         module = importlib.import_module(module_name)
         obj = getattr(module, obj_name)
-    del sys.modules[module_name]
     return obj
 
 

--- a/kipoi/utils.py
+++ b/kipoi/utils.py
@@ -87,6 +87,17 @@ def inherits_from(cls, parent):
     return False
 
 
+def infer_parent_class(cls, class_dict):
+    """Figure out the parent class
+    """
+    type_inferred = None
+    for dl_type in reversed(class_dict):
+        dl_cls = class_dict[dl_type]
+        if inherits_from(cls, dl_cls):
+            return dl_type
+    return type_inferred
+
+
 def pip_install_requirements(requirements_fname):
     if os.path.exists(requirements_fname):  # install dependencies
         logger.info('Running pip install -r {}...'.format(requirements_fname))

--- a/kipoi/utils.py
+++ b/kipoi/utils.py
@@ -53,7 +53,6 @@ def load_obj(obj_import):
         try:
             module = imp.load_module(module_name, fp, pathname, description)
             obj = getattr(module, obj_name)
-            return obj
         except Exception:
             obj = None
         finally:

--- a/tests/test_utils_load_module.py
+++ b/tests/test_utils_load_module.py
@@ -69,3 +69,6 @@ def test_override_default_args():
         override_default_kwargs(A, dict(c=4))
 
 
+def test_sequential_model_loading():
+    m = kipoi.get_model("example/models/kipoi_dataloader_decorator", source='dir')
+    m = kipoi.get_model("example/models/extended_coda", source='dir')

--- a/tests/test_utils_load_module.py
+++ b/tests/test_utils_load_module.py
@@ -1,7 +1,7 @@
 """Test load module
 """
 import kipoi
-from kipoi.utils import load_obj, inherits_from, override_default_kwargs, infer_parent_class
+from kipoi.utils import load_obj, inherits_from, override_default_kwargs, infer_parent_class, cd
 from kipoi.data import BaseDataLoader, Dataset, AVAILABLE_DATALOADERS
 import pytest
 
@@ -70,5 +70,10 @@ def test_override_default_args():
 
 
 def test_sequential_model_loading():
-    m = kipoi.get_model("example/models/kipoi_dataloader_decorator", source='dir')
-    m = kipoi.get_model("example/models/extended_coda", source='dir')
+    m2 = kipoi.get_model("example/models/extended_coda", source='dir')
+    m1 = kipoi.get_model("example/models/kipoi_dataloader_decorator", source='dir')
+
+    with cd(m2.source_dir):
+        next(m2.default_dataloader.init_example().batch_iter())
+    with cd(m1.source_dir):
+        next(m1.default_dataloader.init_example().batch_iter())

--- a/tests/test_utils_load_module.py
+++ b/tests/test_utils_load_module.py
@@ -69,6 +69,14 @@ def test_override_default_args():
         override_default_kwargs(A, dict(c=4))
 
 
+def test_load_obj():
+    with pytest.raises(ImportError):
+        load_obj("asd.dsa")
+
+    with pytest.raises(ImportError):
+        load_obj("keras.dsa")
+
+
 def test_sequential_model_loading():
     m2 = kipoi.get_model("example/models/extended_coda", source='dir')
     m1 = kipoi.get_model("example/models/kipoi_dataloader_decorator", source='dir')

--- a/tests/test_utils_load_module.py
+++ b/tests/test_utils_load_module.py
@@ -1,8 +1,8 @@
 """Test load module
 """
 import kipoi
-from kipoi.utils import load_obj, inherits_from, override_default_kwargs
-from kipoi.data import BaseDataLoader, Dataset
+from kipoi.utils import load_obj, inherits_from, override_default_kwargs, infer_parent_class
+from kipoi.data import BaseDataLoader, Dataset, AVAILABLE_DATALOADERS
 import pytest
 
 
@@ -28,6 +28,17 @@ def test_inherits_from():
     assert inherits_from(Dataset, BaseDataLoader)
     assert not inherits_from(B, BaseDataLoader)
     assert not inherits_from(B, Dataset)
+
+
+def test_infer_parent_class():
+    class A(Dataset):
+        pass
+
+    class B(object):
+        pass
+
+    assert 'Dataset' == infer_parent_class(A, AVAILABLE_DATALOADERS)
+    assert infer_parent_class(B, AVAILABLE_DATALOADERS) is None
 
 
 def test_override_default_args():
@@ -56,3 +67,5 @@ def test_override_default_args():
 
     with pytest.raises(ValueError):
         override_default_kwargs(A, dict(c=4))
+
+


### PR DESCRIPTION
Implements the following API:

Dataloder 
```yaml
type: Dataset  # optional. Only required when specifying a python generator or a function
defined_as: dataloader.SplicingKmerDataset  # Changed from dataloader.py::SplicingKmerDataset
args:
    gtf_file:
        doc: file path; Genome annotation GTF file
        example: example_files/hg19.chr22.gtf
    fasta_file:
        doc: Reference Genome sequence in fasta format
        example: example_files/hg19.chr22.fa  # used for testing
        default:  # used as a default on normal runtime   #  added attribute
           url: path_to_fasta
           md5: ....
```

Custom model
```yaml
defined_as: model.HALModel
args:
  weights:
    url: url
    md5:
  other_arg:
    default:
      url: url
      md5:
  other_arg2: 10
```

Keras model:
```yaml
defined_as: kipoi.model.KerasModel
args:
  weights:
     url: ...
```

