### PR TITLE
kerasModel.input_grad support keras2.2

### DIFF
--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -587,8 +587,7 @@ class KerasModel(BaseModel, GradientMixin, LayerActivationMixin):
         feed_input_names = None
         if keras.__version__[0] == '1':
             feed_input_names = self.model.input_names
-        elif hasattr(keras.engine.training, "_standardize_input_data"):
-            from keras.engine.training import _standardize_input_data
+        else:
             if not hasattr(self.model, "_feed_input_names"):
                 if not self.model.built:
                     self.model.build()
@@ -619,6 +618,15 @@ class KerasModel(BaseModel, GradientMixin, LayerActivationMixin):
             if hasattr(self.model, "_feed_input_shapes"):
                 fis = self.model._feed_input_shapes
             x_standardized = _standardize_input_data(x, feed_input_names, fis)
+        elif hasattr(keras.engine.training_utils, "standardize_input_data"):
+            from keras.engine.training_utils import standardize_input_data
+            if not hasattr(self.model, "_feed_input_names"):
+                if not self.model.built:
+                    self.model.build()
+            fis = None
+            if hasattr(self.model, "_feed_input_shapes"):
+                fis = self.model._feed_input_shapes
+            x_standardized = standardize_input_data(x, feed_input_names, fis)
         else:
             raise Exception("This Keras version is not supported!")
         return x_standardized


### PR DESCRIPTION
- kerasModel.input_grad support keras2.2. Changes made through changing `_batch_to_list` and `_get_feed_input_names` function.