### PR TITLE
Singularity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ variables:
         # TODO only install if singularity is not yet present
         # if type singularity > /dev/null; then exit 0; fi
         SINGULARITY_VER=2.5.1
-        apt-get update; apt-get install squashfs-tools libarchive-dev
+        apt-get update; apt-get install -y squashfs-tools libarchive-dev
         wget https://github.com/singularityware/singularity/releases/download/$SINGULARITY_VER/singularity-$SINGULARITY_VER.tar.gz
         tar xvf singularity-$SINGULARITY_VER.tar.gz
         cd singularity-$SINGULARITY_VER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ variables:
         # TODO only install if singularity is not yet present
         # if type singularity > /dev/null; then exit 0; fi
         SINGULARITY_VER=2.5.1
-        sudo apt-get update; sudo apt-get install squashfs-tools libarchive-dev
+        apt-get update; apt-get install squashfs-tools libarchive-dev
         wget https://github.com/singularityware/singularity/releases/download/$SINGULARITY_VER/singularity-$SINGULARITY_VER.tar.gz
         tar xvf singularity-$SINGULARITY_VER.tar.gz
         cd singularity-$SINGULARITY_VER
         ./configure --prefix=/usr/local --sysconfdir=/etc
         make
-        sudo make install
+        make install
         # conda install --yes -c conda-forge singularity
   install_kipoi_plugins: &install_kipoi_plugins
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ variables:
     run:
       name: Update conda
       command: conda update --yes conda
-  install_git_lfs: &install_git_lfs
+  install_singularity: &install_singularity
     run:
-      name: Install git-lfs
-      command: conda install --yes -c conda-forge git-lfs
+      name: Install Singularity
+      command: conda install --yes -c conda-forge singularity
   install_kipoi_plugins: &install_kipoi_plugins
     run:
       name: Install kipoi plugins
@@ -63,6 +63,7 @@ jobs:
     steps:
       - checkout
       - *update_conda
+      - *install_singularity
       - *install_pip_deps
       - *install_kipoi
       - *install_kipoi_plugins
@@ -80,6 +81,7 @@ jobs:
       - checkout
       - *update_conda
       - *install_pip_deps
+      - *install_singularity
       - *install_kipoi
       - *install_kipoi_plugins
       - *kipoi_ls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,18 @@ variables:
   install_singularity: &install_singularity
     run:
       name: Install Singularity
-      command: conda install --yes -c conda-forge singularity
+      command: |
+        # TODO only install if singularity is not yet present
+        # if type singularity > /dev/null; then exit 0; fi
+        SINGULARITY_VER=2.5.1
+        sudo apt-get update; sudo apt-get install squashfs-tools libarchive-dev
+        wget https://github.com/singularityware/singularity/releases/download/$SINGULARITY_VER/singularity-$SINGULARITY_VER.tar.gz
+        tar xvf singularity-$SINGULARITY_VER.tar.gz
+        cd singularity-$SINGULARITY_VER
+        ./configure --prefix=/usr/local --sysconfdir=/etc
+        make
+        sudo make install
+        # conda install --yes -c conda-forge singularity
   install_kipoi_plugins: &install_kipoi_plugins
     run:
       name: Install kipoi plugins

--- a/kipoi/__init__.py
+++ b/kipoi/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 __author__ = 'Kipoi team'
 __email__ = 'avsec@in.tum.de'
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 
 # available modules

--- a/kipoi/cli/singularity.py
+++ b/kipoi/cli/singularity.py
@@ -46,7 +46,7 @@ def singularity_pull(remote_path, local_path):
     else:
         logger.info("Container file {} doesn't exist. Pulling the container from {}".
                     format(local_path, remote_path))
-        cmd = ['singularity', 'pull', remote_path]
+        cmd = ['singularity', 'pull', '--name', os.path.basename(local_path), remote_path]
         logger.info(" ".join(cmd))
         returncode = subprocess.call(cmd,
                                      cwd=os.path.dirname(local_path))
@@ -94,9 +94,12 @@ def container_remote_url(source='kipoi'):
 
 def container_local_path(remote_path):
     from kipoi.config import _kipoi_dir
-    relative_path, tag = os.path.join(remote_path.split("://")[1]).split(":")
-
-    # TODO - figure out this better
+    tmp = os.path.join(remote_path.split("://")[1])
+    if ":" in tmp:
+        relative_path, tag = tmp.split(":")
+    else:
+        relative_path = tmp
+        tag = 'latest'
     return os.path.join(_kipoi_dir, "envs/singularity/", relative_path + "_" + tag + ".sif")
 
 # ---------------------------------

--- a/kipoi/cli/singularity.py
+++ b/kipoi/cli/singularity.py
@@ -1,0 +1,135 @@
+"""Useful functions for the Singularity containers
+
+TODO:
+- [x] figure out how to mount in other file-systems
+  -B dir1,dir2
+
+Put to release notes:
+`conda install -c bioconda singularity`
+
+OR
+
+`conda install -c conda-forge singularity`
+
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import six
+import os
+from kipoi.utils import unique_list, makedir_exist_ok
+from kipoi.conda import _call_command
+import subprocess
+import logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+# Python wrapper for the Singularity CLI
+# def assert_installed():
+#     """Make sure singularity is installed
+#     """
+#     pass
+
+
+def singularity_pull(remote_path, local_path):
+    """Run `singularity pull`
+
+    Args:
+      remote_path: singularity remote path. Example: shub://kipoi/models:latest
+      local_path: local file path to the ".sif" file
+    """
+    makedir_exist_ok(os.path.dirname(local_path))
+    if os.path.exists(local_path):
+        logger.info("Container file {} already exists. Skipping `singularity pull`".
+                    format(local_path))
+    else:
+        logger.info("Container file {} doesn't exist. Pulling the container from {}".
+                    format(local_path, remote_path))
+        cmd = ['singularity', 'pull', remote_path]
+        logger.info(" ".join(cmd))
+        returncode = subprocess.call(cmd,
+                                     cwd=os.path.dirname(local_path))
+        if returncode != 0:
+            raise ValueError("Command: {} failed".format(" ".join(cmd)))
+        if not os.path.exists(local_path):
+            raise ValueError("Container doesn't exist at the download path: {}".format(local_path))
+
+
+def singularity_exec(container, command, bind_directories=[], dry_run=False):
+    """Run `singularity exec`
+
+    Args:
+      container: path to the singularity image (*.sif)
+      command: command to run (as a list)
+      bind_directories: Additional directories to bind
+    """
+    if bind_directories:
+        options = ['-B', ",".join(bind_directories)]
+    else:
+        options = []
+
+    cmd = ['singularity', 'exec'] + options + [container] + command
+    logger.info(" ".join(cmd))
+    if dry_run:
+        return print(" ".join(cmd))
+    else:
+        returncode = subprocess.call(cmd,
+                                     stdin=subprocess.PIPE)
+    if returncode != 0:
+        raise ValueError("Command: {} failed".format(" ".join(cmd)))
+
+
+# --------------------------------------------
+# Figure out relative paths:
+# - container path (e.g. shub://kipoi/models:latest)
+# - local path (e.g. ~/.kipoi/envs/singularity/kipoi/models_latest.sif)
+
+def container_remote_url(source='kipoi'):
+    if source == 'kipoi':
+        return 'shub://kipoi/models:latest'
+    else:
+        raise NotImplementedError("Containers for sources other than Kipoi are not yet implemented")
+
+
+def container_local_path(remote_path):
+    from kipoi.config import _kipoi_dir
+    relative_path, tag = os.path.join(remote_path.split("://")[1]).split(":")
+
+    # TODO - figure out this better
+    return os.path.join(_kipoi_dir, "envs/singularity/", relative_path + "_" + tag + ".sif")
+
+# ---------------------------------
+
+
+def involved_directories(dataloader_kwargs, output_files=[]):
+    """Infer the involved directories given dataloader kwargs
+    """
+    dirs = []
+    # dataloader kwargs
+    for k, v in six.iteritems(dataloader_kwargs):
+        if os.path.exists(v):
+            dirs.append(os.path.dirname(os.path.abspath(v)))
+
+    # output files
+    for v in output_files:
+        dirs.append(os.path.dirname(os.path.abspath(v)))
+
+    return unique_list(dirs)
+
+
+def singularity_command(kipoi_cmd, model, dataloader_kwargs, output_files=[], source='kipoi', dry_run=False):
+    remote_path = container_remote_url(source)
+    local_path = container_local_path(remote_path)
+    singularity_pull(remote_path, local_path)
+
+    assert kipoi_cmd[0] == 'kipoi'
+
+    # figure out the right cli path
+    stdout, stderr = _call_command('singularity', ['exec', local_path, 'kipoi', 'env', 'get_cli', model], stdin=subprocess.PIPE)
+
+    # run the singularity command
+    kipoi_cmd_conda = [stdout.decode().strip()] + kipoi_cmd[1:]
+    singularity_exec(local_path,
+                     kipoi_cmd_conda,
+                     bind_directories=involved_directories(dataloader_kwargs, output_files), dry_run=dry_run)

--- a/kipoi/cli/singularity.py
+++ b/kipoi/cli/singularity.py
@@ -44,15 +44,15 @@ def singularity_pull(remote_path, local_path):
         logger.info("Container file {} already exists. Skipping `singularity pull`".
                     format(local_path))
     else:
-        if os.environ['SINGULARITY_CACHEDIR']:
-            downloaded_path = os.path.join(os.environ['SINGULARITY_CACHEDIR'],
+        if os.environ.get('SINGULARITY_CACHEDIR'):
+            downloaded_path = os.path.join(os.environ.get('SINGULARITY_CACHEDIR'),
                                            os.path.basename(local_path))
             pull_dir = os.path.dirname(downloaded_path)
             logger.info("SINGULARITY_CACHEDIR is set to {}".
-                        format(os.environ['SINGULARITY_CACHEDIR']))
+                        format(os.environ.get('SINGULARITY_CACHEDIR')))
             if os.path.exists(downloaded_path):
                 logger.info("Container file {} already exists. Skipping `singularity pull` and softlinking it".
-                            format(downloaded_path))                
+                            format(downloaded_path))
                 if os.path.islink(local_path):
                     logger.info("Softlink {} already exists. Removing it".format(local_path))
                     os.remove(local_path)
@@ -73,9 +73,9 @@ def singularity_pull(remote_path, local_path):
                                      cwd=pull_dir)
         if returncode != 0:
             raise ValueError("Command: {} failed".format(" ".join(cmd)))
-        
+
         # softlink it
-        if os.environ['SINGULARITY_CACHEDIR']:
+        if os.environ.get('SINGULARITY_CACHEDIR'):
             if os.path.islink(local_path):
                 logger.info("Softlink {} already exists. Removing it".format(local_path))
                 os.remove(local_path)
@@ -150,7 +150,7 @@ def involved_directories(dataloader_kwargs, output_files=[], exclude_dirs=[]):
     for v in output_files:
         dirs.append(os.path.dirname(os.path.abspath(v)))
 
-    # optionally exclude directories 
+    # optionally exclude directories
     def in_any_dir(fname, dirs):
         return any([is_subdir(fname, os.path.expanduser(d))
                     for d in dirs])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ test_requirements = [
 
 setup(
     name='kipoi',
-    version='0.6.0',
+    version='0.6.1',
     description="Kipoi: model zoo for genomics",
     author="Kipoi team",
     author_email='avsec@in.tum.de',

--- a/tests/cli/test_singularity.py
+++ b/tests/cli/test_singularity.py
@@ -12,7 +12,8 @@ def test_singularity_pull_run(tmpdir):
     output_file = os.path.join(str(tmpdir), "hello-world_latest.sif")
 
     singularity_pull("shub://vsoch/hello-world:latest", output_file)
-    singularity_exec(output_file, ['echo', 'hello-world'])
+    # For now, don't run the command
+    # singularity_exec(output_file, ['echo', 'hello-world'])
 
 
 def test_singularity_command_dry_run():

--- a/tests/cli/test_singularity.py
+++ b/tests/cli/test_singularity.py
@@ -1,0 +1,19 @@
+"""Test kipoi.cli.singularity
+"""
+import os
+from kipoi.cli.singularity import (singularity_pull, singularity_exec,
+                                   container_remote_url, container_local_path,
+                                   involved_directories,
+                                   singularity_command)
+
+
+def test_singularity_pull_run(tmpdir):
+    tmpdir = '/tmp/singularity'
+    output_file = os.path.join(str(tmpdir), "hello-world_latest.sif")
+
+    singularity_pull("shub://vsoch/hello-world:latest", output_file)
+    singularity_exec(output_file, ['echo', 'hello-world'])
+
+
+def test_singularity_command_dry_run():
+    singularity_command(['kipoi', 'test', 'Basset', '--source=kipoi'], 'Basset', {}, dry_run=True)


### PR DESCRIPTION
Adds `--singularity` to `kipoi predict`

## Examples

```bash
kipoi get-example Divergent421 -o example
# Run Divergent
kipoi predict Divergent421 \                                                                                 
  --dataloader_args='{"intervals_file": "example/intervals_file", "fasta_file": "example/fasta_file"}' \
  -o '/tmp/output.tsv' \
  --singularity

# Run Basset
kipoi predict Basset \                                                                                 
  --dataloader_args='{"intervals_file": "example/intervals_file", "fasta_file": "example/fasta_file"}' \
  -o '/tmp/output.tsv' \
  --singularity

```

## Open tasks
- [x] Figure out the output path using:
   - SINGULARITY_CACHEDIR was set to `singularity_cache` (https://singularity.lbl.gov/build-environment)

```bash
INFO [kipoi.cli.main] Running kipoi predict in the singularity container
INFO [kipoi.cli.singularity] Container file /homes/rkreuzhu/.kipoi/envs/singularity/kipoi/models_latest.sif doesn't exist. Pulling the container from shub://kipoi/models:latest
INFO [kipoi.cli.singularity] singularity pull --name models_latest.sif shub://kipoi/models:latest
Progress |===================================| 100.0% 
Done. Container is at: /nfs/research1/stegle/users/rkreuzhu/singularity_cache/models_latest.sif
Traceback (most recent call last):
  File "/nfs/research1/stegle/users/rkreuzhu/conda-envs/kipoi-Divergent421/bin/kipoi", line 11, in <module>
    load_entry_point('kipoi', 'console_scripts', 'kipoi')()
  File "/nfs/research1/stegle/users/rkreuzhu/opt/model-zoo/kipoi/__main__.py", line 104, in main
    command_fn(args.command, sys.argv[2:])
  File "/nfs/research1/stegle/users/rkreuzhu/opt/model-zoo/kipoi/cli/main.py", line 218, in cli_predict
    dry_run=False)
  File "/nfs/research1/stegle/users/rkreuzhu/opt/model-zoo/kipoi/cli/singularity.py", line 127, in singularity_command
    singularity_pull(remote_path, local_path)
  File "/nfs/research1/stegle/users/rkreuzhu/opt/model-zoo/kipoi/cli/singularity.py", line 56, in singularity_pull
    raise ValueError("Container doesn't exist at the download path: {}".format(local_path))
ValueError: Container doesn't exist at the download path: /homes/rkreuzhu/.kipoi/envs/singularity/kipoi/models_latest.sif
```
- [/] allow to specify the container cache path in kipoi's config
  - for now, this is controlled using SINGULARITY_CACHEDIR
- [x] test if home can be mounted within the kipoi docker container
  - if not, don't test it and write it excplititly that we need this feature
  - if yes, don't run `-B folder1,folder2` and instead link the files to the existing paths
     - not possible. Skipping the testing on circleci