### PR TITLE
use converter in favour of deprecated convert in attr.attrib

### DIFF
--- a/.circleci/conda-env.yml
+++ b/.circleci/conda-env.yml
@@ -14,7 +14,7 @@ dependencies:
   - pytest
   - h5py
   - scipy
-  - attr>=17.4.0
+  - attrs>=17.4.0
   # Bio
   - pybigwig
   - pybedtools

--- a/.circleci/conda-env.yml
+++ b/.circleci/conda-env.yml
@@ -14,6 +14,7 @@ dependencies:
   - pytest
   - h5py
   - scipy
+  - attr>=17.4.0
   # Bio
   - pybigwig
   - pybedtools

--- a/kipoi/external/related/fields.py
+++ b/kipoi/external/related/fields.py
@@ -20,7 +20,12 @@ def AnyField(default=NOTHING, required=True, repr=True):
     :param bool cmp: include this field in generated comparison.
     """
     default = _init_fields.init_default(required, default, UNSPECIFIED())
-    return attrib(default=default, convert=None, validator=None,
+    # kw convert is deprecated
+    try:
+        return attrib(default=default, converter=None, validator=None,
+                  repr=repr)
+    except TypeError: # for old versions of attrib we fall back to old keyword convert
+        return attrib(default=default, convert=None, validator=None,
                   repr=repr)
 
 
@@ -39,7 +44,12 @@ def StrSequenceField(cls, default=NOTHING, required=True, repr=True):
     # check that it's not sequence
     converter = to_sequence_field_w_str(cls)
     validator = _init_fields.init_validator(required, types.TypedSequence)
-    return attrib(default=default, convert=converter, validator=validator,
+    # kw convert is deprecated
+    try:
+        return attrib(default=default, converter=converter, validator=validator,
+                  repr=repr)
+    except TypeError:
+        return attrib(default=default, convert=converter, validator=validator,
                   repr=repr)
 
 
@@ -61,9 +71,13 @@ def NestedMappingField(cls, keyword, key, default=NOTHING, required=True, repr=F
     converter = to_leaf_mapping_field(cls, keyword, key)
     # validator = _init_fields.init_validator(required, types.TypedSequence)
     validator = None
-    return attrib(default=default, convert=converter, validator=validator,
+    # kw convert is deprecated
+    try:
+        return attrib(default=default, converter=converter, validator=validator,
                   repr=repr)
-
+    except TypeError:
+        return attrib(default=default, convert=converter, validator=validator,
+                  repr=repr)
 
 def TupleIntField(default=NOTHING, required=True, repr=True):
     """
@@ -79,5 +93,10 @@ def TupleIntField(default=NOTHING, required=True, repr=True):
     default = _init_fields.init_default(required, default, tuple)
     converter = to_eval_str
     validator = _init_fields.init_validator(required, tuple)
-    return attrib(default=default, convert=converter, validator=validator,
+    # kw convert is deprecated
+    try:
+        return attrib(default=default, converter=converter, validator=validator,
+                  repr=repr)
+    except TypeError:
+        return attrib(default=default, convert=converter, validator=validator,
                   repr=repr)

--- a/kipoi/external/related/fields.py
+++ b/kipoi/external/related/fields.py
@@ -20,13 +20,9 @@ def AnyField(default=NOTHING, required=True, repr=True):
     :param bool cmp: include this field in generated comparison.
     """
     default = _init_fields.init_default(required, default, UNSPECIFIED())
-    # kw convert is deprecated
-    try:
-        return attrib(default=default, converter=None, validator=None,
+    return attrib(default=default, converter=None, validator=None,
                   repr=repr)
-    except TypeError: # for old versions of attrib we fall back to old keyword convert
-        return attrib(default=default, convert=None, validator=None,
-                  repr=repr)
+
 
 
 def StrSequenceField(cls, default=NOTHING, required=True, repr=True):
@@ -71,13 +67,9 @@ def NestedMappingField(cls, keyword, key, default=NOTHING, required=True, repr=F
     converter = to_leaf_mapping_field(cls, keyword, key)
     # validator = _init_fields.init_validator(required, types.TypedSequence)
     validator = None
-    # kw convert is deprecated
-    try:
-        return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr)
-    except TypeError:
-        return attrib(default=default, convert=converter, validator=validator,
-                  repr=repr)
+    return attrib(default=default, converter=converter, validator=validator,
+              repr=repr)
+
 
 def TupleIntField(default=NOTHING, required=True, repr=True):
     """
@@ -93,10 +85,5 @@ def TupleIntField(default=NOTHING, required=True, repr=True):
     default = _init_fields.init_default(required, default, tuple)
     converter = to_eval_str
     validator = _init_fields.init_validator(required, tuple)
-    # kw convert is deprecated
-    try:
-        return attrib(default=default, converter=converter, validator=validator,
-                  repr=repr)
-    except TypeError:
-        return attrib(default=default, convert=converter, validator=validator,
-                  repr=repr)
+    return attrib(default=default, converter=converter, validator=validator,
+              repr=repr)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     "numpy",
     "pandas>=0.21.0",
     "tqdm",
-    "attr>=17.4.0",
+    "attrs>=17.4.0",
     "related>=0.6.0",
     "enum34",
     "colorlog",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ requirements = [
     "numpy",
     "pandas>=0.21.0",
     "tqdm",
+    "attr>=17.4.0",
     "related>=0.6.0",
     "enum34",
     "colorlog",


### PR DESCRIPTION
 The keyword ```convert``` in ```attr.attrib``` is deprecated since 2019/01. `converter` has been introduced in  [17.4.0](http://www.attrs.org/en/stable/changelog.html#id44). This PR uses a try except block to first try the new non-deprecated kw, if this fails with a ```TypeError``` (due to a missing kw on a old  attr version ( < 17.4.0)) we catch that in the except block and use the old deprecated kw.