### PR TITLE
replaced deprecated ```logging.warn``` with logging.warning```

### DIFF
--- a/kipoi/__main__.py
+++ b/kipoi/__main__.py
@@ -83,7 +83,7 @@ def main():
                 args.command, commands_str))
     # backwards compatibilty
     if args.command == "postproc":
-        logger.warn("`kipoi postproc` has been deprecated. Please use kipoi <plugin> ...: {}".
+        logger.warning("`kipoi postproc` has been deprecated. Please use kipoi <plugin> ...: {}".
                     format(kipoi.plugin.get_plugin_help()))
         if len(sys.argv) == 2:
             logger.error("Use - kipoi <plugin> <command>.")

--- a/kipoi/cli/env.py
+++ b/kipoi/cli/env.py
@@ -165,7 +165,7 @@ def merge_deps(models,
                                     .format(model_descr.default_dataloader.defined_as))
                                 deps = deps.merge(KIPOISEQ_DEPS)
                             else:
-                                logger.warn("Unable to extract dataloader description. "
+                                logger.warning("Unable to extract dataloader description. "
                                             "Make sure the package containing the dataloader `{}` is installed".
                                             format(model_descr.default_dataloader.defined_as))
                 else:
@@ -301,7 +301,7 @@ def delete_envs(to_delete):
             db.remove(e)
             db.save()
         except Exception as err:
-            logger.warn("Conda delete of environment {0} failed with error: {1}. This environment entry was not "
+            logger.warning("Conda delete of environment {0} failed with error: {1}. This environment entry was not "
                         "removed from the database.".format(e.create_args.env, str(err)))
 
 

--- a/kipoi/cli/main.py
+++ b/kipoi/cli/main.py
@@ -59,7 +59,7 @@ def cli_test(command, raw_args):
 
     if not mh._sufficient_deps(mh.dependencies):
         # model requirements should be installed
-        logger.warn("Required package '{0}' for model type: {1} is not listed in the dependencies".
+        logger.warning("Required package '{0}' for model type: {1} is not listed in the dependencies".
                     format(mh.MODEL_PACKAGE, mh.type))
 
     # Load the test files from model source
@@ -170,7 +170,7 @@ def cli_preproc(command, raw_args):
     for i, batch in enumerate(tqdm(it)):
         # check that the first batch was indeed correct
         if i == 0 and not Dataloader.get_output_schema().compatible_with_batch(batch):
-            logger.warn("First batch of data is not compatible with the dataloader schema.")
+            logger.warning("First batch of data is not compatible with the dataloader schema.")
         writer.batch_write(batch)
 
     writer.close()
@@ -260,7 +260,7 @@ def cli_predict(command, raw_args):
     for i, batch in enumerate(tqdm(it)):
         # validate the data schema in the first iteration
         if i == 0 and not Dl.get_output_schema().compatible_with_batch(batch):
-            logger.warn("First batch of data is not compatible with the dataloader schema.")
+            logger.warning("First batch of data is not compatible with the dataloader schema.")
 
         # make the prediction
         if args.layer is None:

--- a/kipoi/conda/env_db.py
+++ b/kipoi/conda/env_db.py
@@ -75,7 +75,7 @@ class EnvDb:
             try:
                 self.entries.append(EnvDbEntry.from_config(db_entry))
             except Exception as e:
-                logger.warn("Could not load entry with cli path {0} due to: {1}. "
+                logger.warning("Could not load entry with cli path {0} due to: {1}. "
                             "Skipping...".format(str(db_entry), str(e)))
 
     def get_entry_by_model(self, model_name, only_most_recent=True, only_valid=False):

--- a/kipoi/config.py
+++ b/kipoi/config.py
@@ -164,7 +164,7 @@ if os.path.exists(_config_path):
     try:
         _config = yaml_ordered_load(open(_config_path, "r"))
     except ValueError:
-        logger.warn("Unable to parse the config file: {0}. Using default config".format(_config_path))
+        logger.warning("Unable to parse the config file: {0}. Using default config".format(_config_path))
         _model_sources = model_sources()
     else:
         _model_sources = _config['model_sources']

--- a/kipoi/data.py
+++ b/kipoi/data.py
@@ -150,7 +150,7 @@ class BaseDataLoader(object):
         """
         from kipoi.external.related.fields import UNSPECIFIED
         if not hasattr(cls, "args"):
-            logger.warn("No keyword arguments defined for the given dataloader.")
+            logger.warning("No keyword arguments defined for the given dataloader.")
             return None
             # print("No keyword arguments defined for the given dataloader.")
         args = cls.args
@@ -225,7 +225,7 @@ def kipoi_dataloader(override=dict()):
         for i, arg in enumerate(dl_descr.args):
             optional = i >= len(arg_names) - len(default_values)
             if dl_descr.args[arg].optional and not optional:
-                logger.warn("Parameter {} was specified as optional. However, there "
+                logger.warning("Parameter {} was specified as optional. However, there "
                             "are no defaults for it. Specifying it as not optinal".format(arg))
             dl_descr.args[arg].optional = optional
 

--- a/kipoi/external/related/mixins.py
+++ b/kipoi/external/related/mixins.py
@@ -34,7 +34,7 @@ class RelatedConfigMixin(object):
         cfg_keys = set(cfg.keys())
         extra_keys = cfg_keys - cls_keys
         if len(extra_keys) > 0:
-            logger.warn("Unrecognized fields for {0}: {1}. Available fields are {2}".
+            logger.warning("Unrecognized fields for {0}: {1}. Available fields are {2}".
                         format(cls.__name__, extra_keys, cls_keys))
 
         return related.to_model(cls, cfg)

--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -325,7 +325,7 @@ class KerasModel(BaseModel, GradientMixin, LayerActivationMixin):
 
         if self.backend is not None:
             if keras.backend.backend() != self.backend:
-                logger.warn("Keras backend is {0} instead of {1}".
+                logger.warning("Keras backend is {0} instead of {1}".
                             format(keras.backend.backend(), self.backend))
 
         if custom_objects is not None and os.path.exists(custom_objects):
@@ -407,7 +407,7 @@ class KerasModel(BaseModel, GradientMixin, LayerActivationMixin):
             # get the outputs from all nodes of the selected layer (selecting output from individual output nodes
             # creates None entries when running K.gradients())
             if self.get_num_inbound_nodes(selected_layer) > 1:
-                logger.warn("Layer %s has multiple input nodes. By default outputs from all nodes "
+                logger.warning("Layer %s has multiple input nodes. By default outputs from all nodes "
                             "are concatenated" % selected_layer.name)
                 for i in range(self.get_num_inbound_nodes(selected_layer)):
                     sel_output_dims.append(len(selected_layer.get_output_shape_at(i)))
@@ -553,7 +553,7 @@ class KerasModel(BaseModel, GradientMixin, LayerActivationMixin):
             # Which subset of the selected layer outputs should be looked at?
             if filter_slices is not None:
                 if has_concat_output:
-                    logger.warn("Filter slices have been defined for output selection from layers %s, but "
+                    logger.warning("Filter slices have been defined for output selection from layers %s, but "
                                 "layer outputs of nodes had to be concatenated. This will potentially lead to undesired "
                                 "output - please take this concatenation into consideration when "
                                 "defining `filter_slices`." % str([l.name for l in selected_layers]))
@@ -1300,7 +1300,7 @@ class OldPyTorchModel(PyTorchModel):
         Where `weights` is the parameter of this function.
         Partly based on: https://stackoverflow.com/questions/42703500/best-way-to-save-a-trained-model-in-pytorch
         """
-        logger.warn("You are using the old initialisation of Kipoi's pytorch models! This feature will soon be "
+        logger.warning("You are using the old initialisation of Kipoi's pytorch models! This feature will soon be "
                     "removed. Please convert your model to comply with the new definition of loading 'PyTorchModel's.")
         import torch
         if build_fn is not None:

--- a/kipoi/pipeline.py
+++ b/kipoi/pipeline.py
@@ -59,11 +59,11 @@ def validate_kwargs(dataloader, dataloader_kwargs):
                 if not dataloader.args[k].optional}
     missing_arg = req_args - set(dataloader_kwargs.keys())
     if len(missing_arg) > 0:
-        logger.warn("Required arguments for the dataloader: {0} were not specified".
+        logger.warning("Required arguments for the dataloader: {0} were not specified".
                     format(",".join(list(missing_arg))))
     unused = set(dataloader_kwargs.keys()) - set(dataloader.args.keys())
     if len(unused) > 0:
-        logger.warn("Some provided dataloader kwargs were not used: {0}".format(unused))
+        logger.warning("Some provided dataloader kwargs were not used: {0}".format(unused))
     return {k: v for k, v in six.iteritems(dataloader_kwargs) if k in dataloader.args}
 
 
@@ -86,7 +86,7 @@ class Pipeline(object):
 
         # validate if model and datalaoder_cls are compatible
         if not self.model.schema.compatible_with_schema(self.dataloader_cls.get_output_schema()):
-            logger.warn("dataloader.output_schema is not compatible with model.schema")
+            logger.warning("dataloader.output_schema is not compatible with model.schema")
         else:
             logger.info("dataloader.output_schema is compatible with model.schema")
 
@@ -121,7 +121,7 @@ class Pipeline(object):
             pred_list = []
             for i, batch in enumerate(tqdm(it)):
                 if i == 0 and not self.dataloader_cls.get_output_schema().compatible_with_batch(batch):
-                    logger.warn("First batch of data is not compatible with the dataloader schema.")
+                    logger.warning("First batch of data is not compatible with the dataloader schema.")
                 pred_batch = self.model.predict_on_batch(batch['inputs'])
                 pred_list.append(pred_batch)
 
@@ -173,7 +173,7 @@ class Pipeline(object):
 
         for i, batch in enumerate(it):
             if i == 0 and not self.dataloader_cls.get_output_schema().compatible_with_batch(batch):
-                logger.warn("First batch of data is not compatible with the dataloader schema.")
+                logger.warning("First batch of data is not compatible with the dataloader schema.")
             if layer is None:
                 yield self.model.predict_on_batch(batch['inputs'])
             else:
@@ -201,7 +201,7 @@ class Pipeline(object):
 
         for i, batch in enumerate(tqdm(it)):
             if i == 0 and not self.dataloader_cls.get_output_schema().compatible_with_batch(batch):
-                logger.warn("First batch of data is not compatible with the dataloader schema.")
+                logger.warning("First batch of data is not compatible with the dataloader schema.")
             pred_batch = self.model.predict_on_batch(batch['inputs'])
             output_batch = prepare_batch(batch, pred_batch, keep_inputs=keep_inputs)
             writer.batch_write(output_batch)
@@ -262,7 +262,7 @@ class Pipeline(object):
 
         for i, batch in enumerate(it):
             if i == 0 and not self.dataloader_cls.get_output_schema().compatible_with_batch(batch):
-                logger.warn("First batch of data is not compatible with the dataloader schema.")
+                logger.warning("First batch of data is not compatible with the dataloader schema.")
 
             pred = self.model.input_grad(batch['inputs'], filter_idx, avg_func, layer, final_layer,
                                          selected_fwd_node, pre_nonlinearity, **kwargs)

--- a/kipoi/sources.py
+++ b/kipoi/sources.py
@@ -672,7 +672,7 @@ class GitSource(Source):
             return self.clone()
 
         if not self.auto_update:
-            logger.warn("Pulling source even though auto_update=False")
+            logger.warning("Pulling source even though auto_update=False")
 
         logger.info("Update {0}".
                     format(self.local_path))

--- a/kipoi/specs.py
+++ b/kipoi/specs.py
@@ -58,7 +58,7 @@ class Info(RelatedConfigMixin):
 
     def __attrs_post_init__(self):
         if self.authors and self.doc == "":
-            logger.warn("doc empty for the `info:` field")
+            logger.warning("doc empty for the `info:` field")
 
 
 @related.mutable(strict=False)
@@ -500,7 +500,7 @@ class RemoteFile(RelatedConfigMixin):
 
     def __attrs_post_init__(self):
         if self.md5 == "":
-            logger.warn("md5 not specified for url: {}".format(self.url))
+            logger.warning("md5 not specified for url: {}".format(self.url))
 
     def validate(self, path):
         """Validate if the path complies with the provided md5 hash
@@ -534,7 +534,7 @@ class DataLoaderArgument(RelatedConfigMixin):
 
     def __attrs_post_init__(self):
         if self.doc == "":
-            logger.warn("doc empty for one of the dataloader `args` fields")
+            logger.warning("doc empty for one of the dataloader `args` fields")
             # parse args
         self.example = recursive_dict_parse(self.example, 'url', RemoteFile.from_config)
         self.default = recursive_dict_parse(self.default, 'url', RemoteFile.from_config)
@@ -656,7 +656,7 @@ class Dependencies(RelatedConfigMixin):
             channels.insert(channels.index("bioconda") + 1, "conda-forge")
         if "pysam" in packages and "bioconda" in channels:
             if channels.index("defaults") < channels.index("bioconda"):
-                logger.warn("Swapping channel order - putting defaults last. " +
+                logger.warning("Swapping channel order - putting defaults last. " +
                             "Using pysam bioconda instead of anaconda")
                 channels.remove("defaults")
                 channels.insert(len(channels), "defaults")
@@ -740,7 +740,7 @@ class Dependencies(RelatedConfigMixin):
         """
         from sys import platform
         if platform != 'darwin':
-            logger.warn("Calling osx dependency conversion on non-osx platform: {}".
+            logger.warning("Calling osx dependency conversion on non-osx platform: {}".
                         format(platform))
 
         def replace_osx(dep):
@@ -857,7 +857,7 @@ class ModelDescription(RelatedLoadSaveMixin):
 
                     object.__setattr__(self, "postprocessing", self.postprocessing)
                 except Exception:
-                    logger.warn("Unable to parse {} filed in ModelDescription: {}".format(k_observed, self))
+                    logger.warning("Unable to parse {} filed in ModelDescription: {}".format(k_observed, self))
 
         # parse args
         self.args = recursive_dict_parse(self.args, 'url', RemoteFile.from_config)
@@ -968,7 +968,7 @@ class DataLoaderDescription(RelatedLoadSaveMixin):
     def print_kwargs(self, format_examples_json=False):
         from kipoi.external.related.fields import UNSPECIFIED
         if not hasattr(self, "args"):
-            logger.warn("No keyword arguments defined for the given dataloader.")
+            logger.warning("No keyword arguments defined for the given dataloader.")
             return None
 
         args = self.args
@@ -1000,7 +1000,7 @@ class DataLoaderDescription(RelatedLoadSaveMixin):
                     self.postprocessing[k_observed] = parser.from_config(self.postprocessing[k_observed])
                     object.__setattr__(self, "postprocessing", self.postprocessing)
                 except Exception:
-                    logger.warn("Unable to parse {} filed in DataLoaderDescription: {}".format(k_observed, self))
+                    logger.warning("Unable to parse {} filed in DataLoaderDescription: {}".format(k_observed, self))
 
     # download example files
     # def download_example(self):

--- a/kipoi/utils.py
+++ b/kipoi/utils.py
@@ -388,7 +388,7 @@ def lfs_installed(raise_exception=False):
         if raise_exception:
             raise OSError("git-lfs not installed")
         else:
-            logger.warn("git-lfs not installed")
+            logger.warning("git-lfs not installed")
     return ce
 
 

--- a/notebooks/gradient_prediction.ipynb
+++ b/notebooks/gradient_prediction.ipynb
@@ -359,7 +359,7 @@
     "        try:\n",
     "            self.mie = ModelInfoExtractor(md, default_dataloader)\n",
     "        except:\n",
-    "            logger.warn(\"Model is not enabled for variant effect prediction hence it is unclear whether there is a DNA \"\n",
+    "            logger.warning(\"Model is not enabled for variant effect prediction hence it is unclear whether there is a DNA \"\n",
     "                        \"sequence input, so (automatic) seqlogo plots are not available for this model.\")\n",
     "            self.mie = None\n",
     "        self.md = md\n",


### PR DESCRIPTION
This PR tries to replace all  deprecated calls to ```logger.warn``` with ```logger.warning``` :

```logging.warn``` is deprecated since python 3 and shall not be used.
Since python 2.7 also works fine with ```logging.warning```  (```warn``` and ```warning``` are just two names for the same function) it should be fine to just replace all ```logging.warn``` with ```logging.warning```.

This PR is the result of a simple search & replace. 