### PR TITLE
tqdm hotfix

### DIFF
--- a/kipoi/external/torchvision/dataset_utils.py
+++ b/kipoi/external/torchvision/dataset_utils.py
@@ -10,7 +10,9 @@ def gen_bar_updater(pbar):
         if pbar.total is None and total_size:
             pbar.total = total_size
         progress_bytes = count * block_size
-        pbar.update(progress_bytes - pbar.n)
+        n = progress_bytes - pbar.n
+        if n > 0:
+            pbar.update(n)
 
     return bar_update
 


### PR DESCRIPTION
This is a hotfix to adress the issue below
```
Cloning into '/root/.kipoi/models'...
0.00B [00:00, ?B/s]Downloading https://raw.githubusercontent.com/kipoi/kipoiseq/master/tests/data/intervals_51bp.tsv to /example/intervals_file
Failed download. Trying https -> http instead. Downloading http://raw.githubusercontent.com/kipoi/kipoiseq/master/tests/data/intervals_51bp.tsv to /example/intervals_file
Traceback (most recent call last):
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/external/torchvision/dataset_utils.py", line 63, in download_url
   reporthook=gen_bar_updater(tqdm(unit='B', unit_scale=True))
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/urllib/request.py", line 274, in urlretrieve
   reporthook(blocknum, bs, size)
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/external/torchvision/dataset_utils.py", line 13, in bar_update
   pbar.update(progress_bytes - pbar.n)
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/tqdm-4.7.2-py3.6.egg/tqdm/_tqdm.py", line 689, in update
ZeroDivisionError: float division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
 File "/opt/conda/envs/kipoi-dev/bin/kipoi", line 10, in <module>
   sys.exit(main())
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/__main__.py", line 104, in main
   command_fn(args.command, sys.argv[2:])
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/cli/main.py", line 133, in cli_get_example
   kwargs = dl_descr.download_example(output_dir=args.output, dry_run=False)
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/data.py", line 131, in download_example
   return example_kwargs(cls.args, output_dir, absolute_path=absolute_path, dry_run=dry_run)
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/specs.py", line 900, in example_kwargs
   v.example.get_file(path)  # TODO
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/specs.py", line 520, in get_file
   download_url(self.url, root, filename, file_hash)
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/external/torchvision/dataset_utils.py", line 72, in download_url
   reporthook=gen_bar_updater(tqdm(unit='B', unit_scale=True))
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/urllib/request.py", line 274, in urlretrieve
   reporthook(blocknum, bs, size)
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/kipoi/external/torchvision/dataset_utils.py", line 13, in bar_update
   pbar.update(progress_bytes - pbar.n)
 File "/opt/conda/envs/kipoi-dev/lib/python3.6/site-packages/tqdm-4.7.2-py3.6.egg/tqdm/_tqdm.py", line 689, in update
ZeroDivisionError: float division by zero
```