### PR TITLE
better backward comp

### DIFF
--- a/kipoi/external/torchvision/dataset_utils.py
+++ b/kipoi/external/torchvision/dataset_utils.py
@@ -1,2 +1,2 @@
-# this header exisits just for backward compability
+# this header exisits just for backward compatibility
 from kipoi_utils.external.torchvision.dataset_utils import *

--- a/kipoi/external/torchvision/dataset_utils.py
+++ b/kipoi/external/torchvision/dataset_utils.py
@@ -1,0 +1,2 @@
+# this header exisits just for backward compability
+from kipoi_utils.external.torchvision.dataset_utils import *


### PR DESCRIPTION
This PR improves backward compatibility:
to still use the following code in the models:

```python
from kipoi_utils.external.torchvision.dataset_utils import download_url
```
we add the `dataset_utils.py` to kipoi but import the content from kipoi_utils