### PR TITLE
hotfix for recent keras tf combination

### DIFF
--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -328,7 +328,12 @@ class KerasModel(BaseModel, GradientMixin, LayerActivationMixin):
         if self.image_dim_ordering is not None:
             import keras.backend as K
             logger.info("Using image_dim_ordering: {0}".format(self.image_dim_ordering))
-            K.set_image_dim_ordering(self.image_dim_ordering)
+            try:
+                K.set_image_dim_ordering(self.image_dim_ordering)
+            except AttributeError:
+                if image_dim_ordering != 'tf':
+                    raise RuntimeError("only tf")
+
 
         import keras
         from keras.models import model_from_json, load_model

--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -332,7 +332,7 @@ class KerasModel(BaseModel, GradientMixin, LayerActivationMixin):
                 K.set_image_dim_ordering(self.image_dim_ordering)
             except AttributeError:
                 if image_dim_ordering != 'tf':
-                    raise RuntimeError("only tf")
+                    raise RuntimeError("only tf dim ordering at is supported")
 
 
         import keras


### PR DESCRIPTION
for new keras / tf version `  K.set_image_dim_ordering(self.image_dim_ordering)` will fail with an attributeError since `set_image_dim_ordering` is not available any more.

think we can just not call `set_image_dim_ordering` in the case of `tf` dim ordering.
