### PR TITLE
try except block to catch kipoiseq ImportError

### DIFF
--- a/kipoi/cli/main.py
+++ b/kipoi/cli/main.py
@@ -363,14 +363,18 @@ def cli_info(command, raw_args):
     src = kipoi.get_source(args.source)
 
     # load the default dataloader
-    if isinstance(md.default_dataloader, kipoi.specs.DataLoaderImport):
-        with cd(src.get_model_dir(args.model)):
-            dl_descr = md.default_dataloader.get()
-    else:
-        # load from directory
-        # attach the default dataloader already to the model
-        dl_descr = kipoi.get_dataloader_descr(os.path.join(args.model, md.default_dataloader),
-                                              source=args.source)
+    try:
+        if isinstance(md.default_dataloader, kipoi.specs.DataLoaderImport):
+            with cd(src.get_model_dir(args.model)):
+                dl_descr = md.default_dataloader.get()
+        else:
+            # load from directory
+            # attach the default dataloader already to the model
+            dl_descr = kipoi.get_dataloader_descr(os.path.join(args.model, md.default_dataloader),
+                                                  source=args.source)
+    # if kipoiseq is not installed you get an ImportError
+    except ImportError: 
+        dl_descr = None
 
     print("-" * 80)
     print("'{0}' from source '{1}'".format(str(args.model), str(args.source)))
@@ -378,9 +382,10 @@ def cli_info(command, raw_args):
     print("Model information")
     print("-----------")
     print(md.info.get_config_as_yaml())
-    print("Dataloader arguments")
-    print("--------------------")
-    dl_descr.print_args()
+    if dl_descr:
+        print("Dataloader arguments")
+        print("--------------------")
+        dl_descr.print_args()
     print("--------------------\n")
     print("Run `kipoi get-example {} -o example` to download example files.\n".format(args.model))
 


### PR DESCRIPTION
try except to handle the below error

`Traceback (most recent call last):
  File "/usr/local/bin/kipoi", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/kipoi/__main__.py", line 105, in main
    command_fn(args.command, sys.argv[2:])
  File "/usr/local/lib/python3.6/dist-packages/kipoi/cli/main.py", line 368, in cli_info
    dl_descr = md.default_dataloader.get()
  File "/usr/local/lib/python3.6/dist-packages/kipoi/specs.py", line 785, in get
    obj = load_obj(self.defined_as)
  File "/usr/local/lib/python3.6/dist-packages/kipoi_utils/utils.py", line 140, in load_obj
    fp, pathname, description = imp.find_module(module_name)
  File "/usr/lib/python3.6/imp.py", line 297, in find_module
    raise ImportError(_ERR_MSG.format(name), name=name)
ImportError: No module named 'kipoiseq'`