### PR TITLE
Fix tests

### DIFF
--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -34,7 +34,7 @@ dependencies:
   - htslib>=1.7
   - genomelake>=0.1.4
   # ML
-  - scikit-learn>=0.19.1
+  - scikit-learn>=0.19.1,<=0.22
   - tensorflow>=1.4.0
   - pytorch-cpu>=0.3.1
   - keras>=2.2.4

--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -49,6 +49,7 @@ dependencies:
   - cookiecutter>=1.6.0
   - wheel
   - gitpython
+  - pip
   - pip:
     - kipoi-utils>=0.3.8
     - kipoi-conda>=0.1.6

--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -1436,7 +1436,7 @@ class SklearnModel(BaseModel):
     def __init__(self, pkl_file, predict_method="predict"):
         self.pkl_file = pkl_file
 
-        from sklearn.externals import joblib
+        import joblib
         self.model = joblib.load(self.pkl_file)
         assert predict_method in ['predict_proba', 'predict', 'predict_log_proba']
         assert hasattr(self.model, predict_method)


### PR DESCRIPTION
This merge request fixes two problems:
- Deprecated import: `from sklearn.external import joblib`. 
Joblib is a dedicated package now.
- Pin version of sklearn to `<=0.22` because 0.23 fails to load pickled models.

This merge request depends on https://github.com/kipoi/kipoiseq/pull/77