### PR TITLE
Update tinydb purge method to truncate

### DIFF
--- a/kipoi/env_db.py
+++ b/kipoi/env_db.py
@@ -125,7 +125,7 @@ class EnvDb:
         self.entries.append(entry)
 
     def save(self):
-        self.db.purge()
+        self.db.truncate()
         for entry in self.entries:
             self.db.insert(entry.get_config())
 


### PR DESCRIPTION
Hello, I'm having an issue with TinyDB object does not have a method called 'purge'. Seems like it is deprecated. So I just update it to truncate() instead. Can you please check?  Issue is similar to #502 