### PR TITLE
Nightly CI fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ variables:
   install_sys_deps: &install_sys_deps
     run:
       name: install build-essential
-      command: apt-get update && apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc
+      command: apt-get update && apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev
   # install_singularity: &install_singularitymodel
   #   run:
   #     name: Install Singularity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ variables:
   install_sys_deps: &install_sys_deps
     run:
       name: install build-essential
-      command: apt-get update && apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev
+      command: apt-get update && apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc
   # install_singularity: &install_singularitymodel
   #   run:
   #     name: Install Singularity
@@ -136,7 +136,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - *update_conda
+      # - *update_conda
       #- *install_sys_deps
       - *install_from_dev_requirements_py36
       #- *install_singularity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ variables:
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py36.yml
         source activate kipoi-env
-        conda install gcc_linux-64
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ variables:
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py36.yml
         source activate kipoi-env
+        conda install gcc_linux-64
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -136,7 +137,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      # - *update_conda
+      - *update_conda
       #- *install_sys_deps
       - *install_from_dev_requirements_py36
       #- *install_singularity

--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -6,6 +6,7 @@ channels:
   - defaults
 dependencies:
   - python=3.6
+  - gcc_linux-64
   # general packages
   # - git-lfs 
   # General

--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -29,6 +29,7 @@ dependencies:
   - pyvcf>=0.6.8
   - pysam>=0.14.0
   - pyfaidx>=0.5.5.2
+  - cython=0.29.23
   - cyvcf2>=0.8.4
   - bedtools>=2.27.1
   - htslib>=1.7


### PR DESCRIPTION
I had to explicitly add gcc inside the environment. I suspect it is due to an updated conda version. I intentionally did not pin the version because we most likely would want to know if the setup fails for a certain version of conda.

Any opinion?