### PR TITLE
Fixed ci for python3.6

### DIFF
--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -55,6 +55,6 @@ dependencies:
     - kipoi-conda>=0.1.6
     - kipoi-interpret>=0.1.2
     - kipoi-veff>=0.3.0
-    - git+https://github.com/kipoi/kipoiseq.git@add-one-hot-encode
+    - kipoiseq
     - concise>=0.6.5
     - joblib==0.17.0

--- a/kipoi/cli/main.py
+++ b/kipoi/cli/main.py
@@ -289,7 +289,10 @@ def cli_predict(command, raw_args):
         if args.layer is None:
             pred_batch = model.predict_on_batch(batch['inputs'])
         else:
-            pred_batch = model.predict_activation_on_batch(batch['inputs'], layer=args.layer)
+            if isinstance(batch["inputs"], np.ndarray):
+                pred_batch = model.predict_activation_on_batch(batch['inputs'].astype(np.float32), layer=args.layer)
+            else:      
+                pred_batch = model.predict_activation_on_batch(batch['inputs'], layer=args.layer)
 
         # write out the predictions, metadata (, inputs, targets)
         output_batch = prepare_batch(batch, pred_batch, keep_inputs=args.keep_inputs, keep_metadata=args.keep_metadata)

--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -995,7 +995,7 @@ class PyTorchModel(BaseModel, GradientMixin, LayerActivationMixin):
         input = self.numpy_to_torch(x, requires_grad=requires_grad)
         if isinstance(x, np.ndarray):
             # convert to a pytorch tensor and then to a pytorch variable
-            pred = self.model(input)
+            pred = self.model(input.astype(np.float32))
 
         elif isinstance(x, dict):
             # convert all entries in the dict to pytorch variables

--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -995,7 +995,7 @@ class PyTorchModel(BaseModel, GradientMixin, LayerActivationMixin):
         input = self.numpy_to_torch(x, requires_grad=requires_grad)
         if isinstance(x, np.ndarray):
             # convert to a pytorch tensor and then to a pytorch variable
-            pred = self.model(input.astype(np.float32))
+            pred = self.model(input.float())
 
         elif isinstance(x, dict):
             # convert all entries in the dict to pytorch variables

--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -995,7 +995,7 @@ class PyTorchModel(BaseModel, GradientMixin, LayerActivationMixin):
         input = self.numpy_to_torch(x, requires_grad=requires_grad)
         if isinstance(x, np.ndarray):
             # convert to a pytorch tensor and then to a pytorch variable
-            pred = self.model(input.float())
+            pred = self.model(input)
 
         elif isinstance(x, dict):
             # convert all entries in the dict to pytorch variables

--- a/kipoi/pipeline.py
+++ b/kipoi/pipeline.py
@@ -14,6 +14,7 @@ import six
 import deprecation
 from ._version import __version__
 import logging
+import numpy as np
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -134,7 +135,10 @@ class Pipeline(object):
             for i, batch in enumerate(tqdm(it)):
                 if i == 0 and not self.dataloader_cls.get_output_schema().compatible_with_batch(batch):
                     logger.warning("First batch of data is not compatible with the dataloader schema.")
-                pred_batch = self.model.predict_on_batch(batch['inputs'])
+                if isinstance(batch["inputs"], np.ndarray):
+                    pred_batch = self.model.predict_on_batch(batch['inputs'].astype(np.float32))
+                else:
+                    pred_batch = self.model.predict_on_batch(batch['inputs'])
                 if 'keep_metadata' in kwargs and kwargs.get('keep_metadata') and 'metadata' in batch:
                     pred_list.append({'preds':pred_batch, 'metadata': batch['metadata']})
                 else:

--- a/tests/test_13_data_examples.py
+++ b/tests/test_13_data_examples.py
@@ -9,6 +9,7 @@ import kipoi
 import kipoi_utils.utils
 from kipoi.pipeline import install_model_requirements
 import config
+import numpy as np 
 
 # TODO - check if you are on travis or not regarding the --install-req flag
 # INSTALL_REQ = True
@@ -42,7 +43,6 @@ def test_dataloader_model(example):
     Dl = kipoi.get_dataloader_factory(example_dir, source="dir")
 
     test_kwargs = Dl.example_kwargs
-
     # get dataloader
 
     # get model
@@ -55,5 +55,8 @@ def test_dataloader_model(example):
         # sample a batch of data
         it = dataloader.batch_iter()
         batch = next(it)
-        # predict with a model
-        model.predict_on_batch(batch["inputs"])
+        # predict with a model        
+        if isinstance(batch["inputs"], np.ndarray):
+            model.predict_on_batch(batch["inputs"].astype(np.float32))
+        else:
+            model.predict_on_batch(batch["inputs"])


### PR DESCRIPTION
Although the conda environment, base docker container and pytorch version are identical  between last successful run and now, for some reason floats are misinterpreted as doubles. I have fixed it but the fix is a bit hacky. However, none of the models are complaining https://app.circleci.com/pipelines/github/kipoi/models/835/workflows/20210196-6f06-4518-a042-2eed1ec66e4c. I am merging this for now but we can discuss further if you know of a better solution