### PR TITLE
Fixed ci for python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ variables:
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
+        conda install -y matplotlib tinydb
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ variables:
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
-        conda install -y matplotlib tinydb
+        conda install -y -c conda-forge matplotlib tinydb
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -263,10 +263,8 @@ workflows:
   # tag commits: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
   test-n-deploy:
     jobs:
+      - test-py36-yml
       - test-py37-yml
-      - test-py36-yml:
-          requires:
-            - test-py37-yml
       - build-deploy-docs:
           requires:
             - test-py36-yml
@@ -309,6 +307,4 @@ workflows:
                 - master
     jobs:
       - test-py36-yml
-      - test-py37-yml:
-          requires:
-            - test-py36-yml
+      - test-py37-yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,9 +274,11 @@ workflows:
   test-n-deploy:
     jobs:
       - test-py36-yml
+      - test-py37-yml
       - build-deploy-docs:
           requires:
             - test-py36-yml
+            - test-py37-yml
           filters:
             branches:
               only:
@@ -285,6 +287,7 @@ workflows:
       - test-deploy-pypi:
           requires:
             - test-py36-yml
+            - test-py37-yml
           filters:
 #            tags:
 #              only: /^v.*/
@@ -295,6 +298,7 @@ workflows:
       - productive-deploy-pypi:
           requires:
             - test-py36-yml
+            - test-py37-yml
           filters:
 #            # Trigger only on a tagged commit starting with v.
 #            # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
@@ -313,3 +317,4 @@ workflows:
                 - master
     jobs:
       - test-py36-yml
+      - test-py37-yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,23 +260,21 @@ workflows:
 
   # TODO - consider running the deploy only on
   # tag commits: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
-  test-n-deploy:
+  test-py36:
     jobs:
       - test-py36-yml
-      - test-py37-yml
+  test-py37:
+    jobs:
+      - test-py37-yml    
+  deploy:
+    jobs:
       - build-deploy-docs:
-          requires:
-            - test-py36-yml
-            - test-py37-yml
           filters:
             branches:
               only:
                 - master
                 - test_deployment_script
       - test-deploy-pypi:
-          requires:
-            - test-py36-yml
-            - test-py37-yml
           filters:
 #            tags:
 #              only: /^v.*/
@@ -285,9 +283,6 @@ workflows:
                 - test_deployment_pypi
                 - test_deployment_script
       - productive-deploy-pypi:
-          requires:
-            - test-py36-yml
-            - test-py37-yml
           filters:
 #            # Trigger only on a tagged commit starting with v.
 #            # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,21 +260,25 @@ workflows:
 
   # TODO - consider running the deploy only on
   # tag commits: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
-  test-py36:
+  test-n-deploy:
     jobs:
       - test-py36-yml
-  test-py37:
-    jobs:
-      - test-py37-yml    
-  deploy:
-    jobs:
+      - test-py37-yml
+          requires:
+            - test-py36-yml
       - build-deploy-docs:
+          requires:
+            - test-py36-yml
+            - test-py37-yml
           filters:
             branches:
               only:
                 - master
                 - test_deployment_script
       - test-deploy-pypi:
+          requires:
+            - test-py36-yml
+            - test-py37-yml
           filters:
 #            tags:
 #              only: /^v.*/
@@ -283,6 +287,9 @@ workflows:
                 - test_deployment_pypi
                 - test_deployment_script
       - productive-deploy-pypi:
+          requires:
+            - test-py36-yml
+            - test-py37-yml
           filters:
 #            # Trigger only on a tagged commit starting with v.
 #            # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
@@ -302,3 +309,5 @@ workflows:
     jobs:
       - test-py36-yml
       - test-py37-yml
+          requires:
+            - test-py36-yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ workflows:
   test-n-deploy:
     jobs:
       - test-py36-yml
-      - test-py37-yml
+      - test-py37-yml:
           requires:
             - test-py36-yml
       - build-deploy-docs:
@@ -308,6 +308,6 @@ workflows:
                 - master
     jobs:
       - test-py36-yml
-      - test-py37-yml
+      - test-py37-yml:
           requires:
             - test-py36-yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ variables:
 jobs:
   test-py36-yml:
     docker:
-      - image: continuumio/miniconda3:4.5.12
+      - image: continuumio/miniconda3:latest
     working_directory: ~/repo
     steps:
       - checkout
@@ -158,7 +158,7 @@ jobs:
       - *store_test_artifacts
   test-py37-yml:
     docker:
-      - image: continuumio/miniconda3:4.5.12
+      - image: continuumio/miniconda3:latest
     working_directory: ~/repo
     steps:
       - checkout
@@ -201,7 +201,7 @@ jobs:
 
   test-deploy-pypi:
     docker:
-      - image: continuumio/miniconda3:4.7.10
+      - image: continuumio/miniconda3:latest
     working_directory: ~/repo
     steps:
       - checkout
@@ -229,7 +229,7 @@ jobs:
 
   productive-deploy-pypi:
     docker:
-      - image: continuumio/miniconda3:4.7.10
+      - image: continuumio/miniconda3:latest
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ variables:
     run:
       name: Install miniconda3
       command: |
-       sudo apt-get update && apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc && \
+        sudo apt-get update && sudo apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc && \
         wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
         /bin/bash ~/miniconda.sh -b && \
         rm ~/miniconda.sh && \
@@ -177,7 +177,6 @@ jobs:
       - checkout
       - *install_conda
       - *update_conda
-      - *install_sys_deps
       - *install_from_dev_requirements_py37
       #- *install_singularity
       - *export_shortcuts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ variables:
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
+        conda install -c conda-forge matplotlib
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,15 @@ variables:
     run:
       name: Install miniconda3
       command: |
-        export PATH="/opt/conda/bin:$PATH"
-        apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates curl git && \
-        apt-get clean && rm -rf /var/lib/apt/lists/*
+       sudo apt-get update && apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc && \
         wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
-        /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+        /bin/bash ~/miniconda.sh -b && \
         rm ~/miniconda.sh && \
-        /opt/conda/bin/conda clean -tipsy && \
-        ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-        echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-        echo "conda activate base" >> ~/.bashrc
+        ~/miniconda3/bin/conda clean -tipsy && \
+        sudo ln -s ~/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+        echo ". ~/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
+        echo "conda activate base" >> ~/.bashrc && \
+        source ~/.bashrc
   update_conda: &update_conda
     run:
       name: Update conda
@@ -172,7 +171,7 @@ jobs:
       - *store_test_artifacts
   test-py37-yml:
     machine: # executor type
-      image: ubuntu-2004:202010-01
+      image: ubuntu-1604:202104-01
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,16 @@ variables:
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
-
+  install_from_dev_requirements_py37: &install_from_dev_requirements_py37
+    run:
+      name: Install from dev-requirements-py37.yml
+      command: |
+        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
+        conda env create --name kipoi-env -f dev-requirements-py37.yml
+        source activate kipoi-env
+        pip install -e .
+        git lfs install
+        # ln -s /opt/conda/bin/python /usr/bin/python
   install_kipoi: &install_kipoi
     run:
       name: Install Kipoi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,10 +262,10 @@ workflows:
   # tag commits: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
   test-n-deploy:
     jobs:
-      - test-py36-yml
-      - test-py37-yml:
+      - test-py37-yml
+      - test-py36-yml:
           requires:
-            - test-py36-yml
+            - test-py37-yml
       - build-deploy-docs:
           requires:
             - test-py36-yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ variables:
       command: |
         pip install kipoi_interpret
         pip install kipoi_veff
-        pip install git+https://github.com/kipoi/kipoiseq.git@add-one-hot-encode
+        pip install kipoiseq
         pip install pyfaidx
         conda install --yes -c conda-forge fastparquet zarr numcodecs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,13 +156,16 @@ jobs:
       - *store_test_results
       - *store_test_artifacts
   test-py37-yml:
-    machine: # executor type
-      image: ubuntu-1604:202104-01
+    # machine: # executor type
+    #   image: ubuntu-1604:202104-01
+    docker:
+      - image: continuumio/miniconda3:4.5.12
     working_directory: ~/repo
     steps:
       - checkout
-      - *install_conda
+      # - *install_conda
       - *update_conda
+      - *install_sys_deps
       - *install_from_dev_requirements_py37
       #- *install_singularity
       - *export_shortcuts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,20 @@
 version: 2
 
 variables:
+  install_conda: &install_conda
+    run:
+      name: Install miniconda3
+      command: |
+        export PATH="/opt/conda/bin:$PATH"
+        apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates curl git && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*
+        wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
+        /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+        rm ~/miniconda.sh && \
+        /opt/conda/bin/conda clean -tipsy && \
+        ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+        echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+        echo "conda activate base" >> ~/.bashrc
   update_conda: &update_conda
     run:
       name: Update conda
@@ -62,7 +76,6 @@ variables:
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
-        conda install -y -c conda-forge matplotlib tinydb
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -158,11 +171,12 @@ jobs:
       - *store_test_results
       - *store_test_artifacts
   test-py37-yml:
-    docker:
-      - image: continuumio/miniconda3:4.5.12
+    machine: # executor type
+      image: ubuntu-2004:202010-01
     working_directory: ~/repo
     steps:
       - checkout
+      - *install_conda
       - *update_conda
       - *install_sys_deps
       - *install_from_dev_requirements_py37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ variables:
 jobs:
   test-py36-yml:
     docker:
-      - image: continuumio/miniconda3:latest
+      - image: continuumio/miniconda3:4.5.12
     working_directory: ~/repo
     steps:
       - checkout
@@ -159,7 +159,7 @@ jobs:
       - *store_test_artifacts
   test-py37-yml:
     docker:
-      - image: continuumio/miniconda3:latest
+      - image: continuumio/miniconda3:4.5.12
     working_directory: ~/repo
     steps:
       - checkout
@@ -202,7 +202,7 @@ jobs:
 
   test-deploy-pypi:
     docker:
-      - image: continuumio/miniconda3:latest
+      - image: continuumio/miniconda3:4.7.10
     working_directory: ~/repo
     steps:
       - checkout
@@ -230,7 +230,7 @@ jobs:
 
   productive-deploy-pypi:
     docker:
-      - image: continuumio/miniconda3:latest
+      - image: continuumio/miniconda3:4.7.10
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,10 @@ variables:
         sudo ln -s ~/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
         echo ". ~/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
         echo "conda activate base" >> ~/.bashrc && \
-        source ~/.bashrc
   update_conda: &update_conda
     run:
       name: Update conda
-      command: conda update -n base conda -c anaconda
+      command: source ~/.bashrc && conda update -n base conda -c anaconda
   install_sys_deps: &install_sys_deps
     run:
       name: install build-essential
@@ -72,6 +71,7 @@ variables:
     run:
       name: Install from dev-requirements-py37.yml
       command: |
+        source ~/.bashrc
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env

--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -55,6 +55,6 @@ dependencies:
     - kipoi-conda>=0.1.6
     - kipoi-interpret>=0.1.2
     - kipoi-veff>=0.3.0
-    - git+https://github.com/kipoi/kipoiseq.git@add-one-hot-encode
+    - kipoiseq
     - concise>=0.6.5
     - joblib==0.17.0

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -22,8 +22,6 @@ dependencies:
   - cyvcf2>=0.8.4
   - bedtools>=2.27.1
   - htslib>=1.7
-  - matplotlib
-  - tinydb
   # ML
   - scikit-learn>=0.19.1,<=0.22
   - tensorflow==1.13.1

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -22,6 +22,8 @@ dependencies:
   - cyvcf2>=0.8.4
   - bedtools>=2.27.1
   - htslib>=1.7
+  - matplotlib
+  - tinydb
   # ML
   - scikit-learn>=0.19.1,<=0.22
   - tensorflow==1.13.1

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -31,6 +31,8 @@ dependencies:
   - fastparquet
   - zarr 
   - numcodecs
+  - matplotlib
+  - tinydb>=3.12.2
   # singularity
   #- singularity
   - git

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -6,25 +6,14 @@ channels:
   - defaults
 dependencies:
   - python=3.7
-  # general packages
-  # - git-lfs 
-  # General
   - numpy>=1.13.0
   - pandas
   - pytest>=3.3.1
-  - pytest-xdist
-  - pytest-sugar
   - pytest-cov>=2.6.1
-  - deprecation>=2.0.6
   #- coveralls
   - h5py==2.10.0
   - scipy>=1.0.0
-  - attrs>=18.2.0
-  - matplotlib
-  - tinydb>=3.12.2
-  # Bio
   - pybigwig>=0.3.10
-  # could not pin pydedtools ins conda
   - pybedtools>=0.7.10
   - pyvcf>=0.6.8
   - pysam>=0.14.0

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -31,7 +31,6 @@ dependencies:
   - fastparquet
   - zarr 
   - numcodecs
-  - matplotlib
   - tinydb>=3.12.2
   # singularity
   #- singularity

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -55,6 +55,6 @@ dependencies:
     - kipoi-conda>=0.1.6
     - kipoi-interpret>=0.1.2
     - kipoi-veff>=0.3.0
-    - git+https://github.com/kipoi/kipoiseq.git@add-one-hot-encode
+    - kipoiseq
     - concise>=0.6.5
     - joblib==0.17.0


### PR DESCRIPTION
It seems for python 3.7  installing conda environment is running out of memory inside the docker executor. Installing matplotlib separately seems to do the trick. I am merging this for now but I will experiment with a machine executor which has more RAM (7.5 GB) than docker executor (4 GB) in a separate attempt. 