### PR TITLE
Add machine executor for testing with python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,7 @@ variables:
         /bin/bash ~/miniconda.sh -b && \
         rm ~/miniconda.sh && \
         ~/miniconda3/bin/conda clean -tipsy && \  
-        sudo ln -s ~/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-        echo ". ~/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
-        echo "conda activate base" >> ~/.bashrc && \
+
         export PATH=$HOME/miniconda/bin:$PATH
   update_conda: &update_conda
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,6 @@ variables:
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
-        conda install -c conda-forge matplotlib
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -166,14 +165,14 @@ jobs:
       - *store_test_results
       - *store_test_artifacts
   test-py37-yml:
-    # machine: # executor type
-    #   image: ubuntu-1604:202104-01
-    docker:
-      - image: continuumio/miniconda3:4.5.12
+    machine: # executor type
+      image: ubuntu-1604:202104-01
+    # docker:
+    #   - image: continuumio/miniconda3:4.5.12
     working_directory: ~/repo
     steps:
       - checkout
-      # - *install_conda
+      - *install_conda
       - *update_conda
       - *install_sys_deps
       - *install_from_dev_requirements_py37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ variables:
       name: Export shortcuts
       command: |
         # for no good reason the wrong version of pytest is choosen by default...
+        source ~/.bashrc
         echo 'export PYTEST=$(conda info --base)/envs/kipoi-env/bin/pytest' >> $BASH_ENV
   install_from_dev_requirements_py36: &install_from_dev_requirements_py36
     run:
@@ -92,7 +93,7 @@ variables:
     run:
       name: List kipoi packages
       command: |
-        export PATH="$HOME/miniconda/bin:$PATH"
+        source ~/.bashrc
         source activate kipoi-env
         kipoi ls
   # run_coveralls: &run_coveralls
@@ -100,7 +101,7 @@ variables:
     run:
       name: Run tests
       command: |
-        export PATH="$HOME/miniconda/bin:$PATH"
+        source ~/.bashrc
         source activate kipoi-env
         mkdir test-reports
         $PYTEST --cov=kipoi/ tests/ -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ variables:
         cd $HOME && \
         wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
         /bin/bash ~/miniconda.sh -b && \
-        ~/miniconda3/bin/conda clean -tipsy && \  
         export PATH=$HOME/miniconda/bin:$PATH
   update_conda: &update_conda
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,8 @@ variables:
     run:
       name: Install from dev-requirements-py37.yml
       command: |
-        export PATH="$HOME/miniconda/bin:$PATH"
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
+        source ~/.bashrc
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
         pip install -e .
@@ -92,8 +92,8 @@ variables:
   kipoi_ls2: &activate_and_kipoi_ls
     run:
       name: List kipoi packages
-      command: |
-        export PATH="$HOME/miniconda/bin:$PATH"
+      command: |  
+        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         source ~/.bashrc
         source activate kipoi-env
         kipoi ls
@@ -102,7 +102,7 @@ variables:
     run:
       name: Run tests
       command: |
-        export PATH="$HOME/miniconda/bin:$PATH"
+        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         source ~/.bashrc
         source activate kipoi-env
         mkdir test-reports
@@ -116,7 +116,6 @@ variables:
     run:
       name: activate and run coveralls
       command: |
-        export PATH="$HOME/miniconda/bin:$PATH"
         source activate kipoi-env
         coveralls || true
   store_test_results: &store_test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,8 @@ variables:
     run:
       name: Install from dev-requirements-py37.yml
       command: |
+        export PATH="~/miniconda3/bin:$PATH"
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        source ~/.bashrc
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
         pip install -e .
@@ -93,8 +93,8 @@ variables:
     run:
       name: List kipoi packages
       command: |  
+        export PATH="~/miniconda3/bin:$PATH"
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        source ~/.bashrc
         source activate kipoi-env
         kipoi ls
   # run_coveralls: &run_coveralls
@@ -102,8 +102,8 @@ variables:
     run:
       name: Run tests
       command: |
+        export PATH="~/miniconda3/bin:$PATH"
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        source ~/.bashrc
         source activate kipoi-env
         mkdir test-reports
         $PYTEST --cov=kipoi/ tests/ -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ variables:
         ~/miniconda3/bin/conda clean -tipsy && \
         sudo ln -s ~/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
         echo ". ~/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
-        echo "conda activate base" >> ~/.bashrc && \
+        echo "conda activate base" >> ~/.bashrc 
   update_conda: &update_conda
     run:
       name: Update conda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ variables:
       name: Install miniconda3
       command: |
         sudo apt-get update && sudo apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc && \
-        wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
+        wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh -O ~/miniconda.sh && \
         /usr/bin/bash ~/miniconda.sh -b && \
         rm ~/miniconda.sh && \
         ~/miniconda3/bin/conda clean -tipsy && \
@@ -16,7 +16,7 @@ variables:
   update_conda: &update_conda
     run:
       name: Update conda
-      command: source ~/.bashrc && conda update -n base conda -c anaconda
+      command: conda update -n base conda -c anaconda
   install_sys_deps: &install_sys_deps
     run:
       name: install build-essential
@@ -69,6 +69,7 @@ variables:
     run:
       name: Install from dev-requirements-py37.yml
       command: |  
+        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
         pip install -e .
@@ -258,7 +259,7 @@ jobs:
       - run:
           name: pip install from PyPI
           command: |
-            conda activate kipoi-env
+            source activate kipoi-env
             python -m pip install --user kipoi --verbose
             python -c "import kipoi; print(kipoi.__version__)"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ variables:
       command: |
         sudo apt-get update && sudo apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc && \
         cd $HOME && \
-        wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
-        /bin/bash ~/miniconda.sh -b && \
+        wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O $HOME/miniconda.sh && \
+        /usr/bin/bash $HOME/miniconda.sh -b && \
         export PATH=$HOME/miniconda/bin:$PATH
   update_conda: &update_conda
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ variables:
     run:
       name: List kipoi packages
       command: |
+        export PATH="$HOME/miniconda/bin:$PATH"
         source ~/.bashrc
         source activate kipoi-env
         kipoi ls
@@ -101,6 +102,7 @@ variables:
     run:
       name: Run tests
       command: |
+        export PATH="$HOME/miniconda/bin:$PATH"
         source ~/.bashrc
         source activate kipoi-env
         mkdir test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,11 +69,10 @@ variables:
   install_from_dev_requirements_py37: &install_from_dev_requirements_py37
     run:
       name: Install from dev-requirements-py37.yml
-      command: |
-        source ~/.bashrc
+      command: |  
+        export PATH="~/miniconda3/bin:$PATH"
         conda env create --name kipoi-env -f dev-requirements-py37.yml
-        source ~/.bashrc
-        conda activate kipoi-env
+        source activate kipoi-env
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -103,6 +102,7 @@ variables:
       command: |
         source ~/.bashrc
         source activate kipoi-env
+        export PATH="~/miniconda3/bin:$PATH"
         mkdir test-reports
         $PYTEST --cov=kipoi/ tests/ -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
       no_output_timeout: 15m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,14 +167,11 @@ jobs:
   test-py37-yml:
     machine: # executor type
       image: ubuntu-1604:202104-01
-    # docker:
-    #   - image: continuumio/miniconda3:4.5.12
     working_directory: ~/repo
     steps:
       - checkout
       - *install_conda
       - *update_conda
-      - *install_sys_deps
       - *install_from_dev_requirements_py37
       #- *install_singularity
       - *export_shortcuts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ variables:
     run:
       name: activate and run coveralls
       command: |
-        source activate kipoi-env
+        source ~/.bashrc
+        conda activate kipoi-env
         coveralls || true
   store_test_results: &store_test_results
     store_test_results:
@@ -127,7 +128,8 @@ variables:
     run:
       name: build python packages
       command: |
-        source activate kipoi-env
+        source ~/.bashrc
+        conda activate kipoi-env
         python setup.py sdist bdist_wheel
   conda_install_twine: &conda_install_twine
     run:
@@ -234,7 +236,8 @@ jobs:
       - run:
           name: pip install from TestPyPI
           command: |
-            source activate kipoi-env
+            source ~/.bashrc
+            conda activate kipoi-env
             python -m pip install --user --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple kipoi --verbose
             python -c "import kipoi; print(kipoi.__version__)"
 
@@ -262,7 +265,8 @@ jobs:
       - run:
           name: pip install from PyPI
           command: |
-            source activate kipoi-env
+            source ~/.bashrc
+            conda activate kipoi-env
             python -m pip install --user kipoi --verbose
             python -c "import kipoi; print(kipoi.__version__)"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,19 @@ variables:
       name: Install miniconda3
       command: |
         sudo apt-get update && sudo apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc && \
+        cd $HOME && \
         wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
         /bin/bash ~/miniconda.sh -b && \
         rm ~/miniconda.sh && \
-        ~/miniconda3/bin/conda clean -tipsy && \
+        ~/miniconda3/bin/conda clean -tipsy && \  
         sudo ln -s ~/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
         echo ". ~/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
-        echo "conda activate base" >> ~/.bashrc 
+        echo "conda activate base" >> ~/.bashrc && \
+        export PATH=$HOME/miniconda/bin:$PATH
   update_conda: &update_conda
     run:
       name: Update conda
-      command: source ~/.bashrc && conda update -n base conda -c anaconda
+      command: export PATH="$HOME/miniconda/bin:$PATH" && conda update -n base conda -c anaconda
   install_sys_deps: &install_sys_deps
     run:
       name: install build-essential
@@ -69,10 +71,10 @@ variables:
     run:
       name: Install from dev-requirements-py37.yml
       command: |
-        source ~/.bashrc
+        export PATH="$HOME/miniconda/bin:$PATH"
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
-        conda activate kipoi-env
+        source activate kipoi-env
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -92,16 +94,16 @@ variables:
     run:
       name: List kipoi packages
       command: |
-        source ~/.bashrc
-        conda activate kipoi-env
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate kipoi-env
         kipoi ls
   # run_coveralls: &run_coveralls
   activate_and_run_tests: &activate_and_run_tests
     run:
       name: Run tests
       command: |
-        source ~/.bashrc
-        conda activate kipoi-env
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate kipoi-env
         mkdir test-reports
         $PYTEST --cov=kipoi/ tests/ -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
       no_output_timeout: 15m
@@ -113,8 +115,8 @@ variables:
     run:
       name: activate and run coveralls
       command: |
-        source ~/.bashrc
-        conda activate kipoi-env
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate kipoi-env
         coveralls || true
   store_test_results: &store_test_results
     store_test_results:
@@ -128,8 +130,8 @@ variables:
     run:
       name: build python packages
       command: |
-        source ~/.bashrc
-        conda activate kipoi-env
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate kipoi-env
         python setup.py sdist bdist_wheel
   conda_install_twine: &conda_install_twine
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,9 @@ variables:
     run:
       name: Install from dev-requirements-py37.yml
       command: |
-        export PATH="~/miniconda3/bin:$PATH"
-        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
+        source ~/.bashrc
         conda env create --name kipoi-env -f dev-requirements-py37.yml
-        source activate kipoi-env
+        conda activate kipoi-env
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -93,18 +92,16 @@ variables:
     run:
       name: List kipoi packages
       command: |  
-        export PATH="~/miniconda3/bin:$PATH"
-        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        source activate kipoi-env
+        source ~/.bashrc
+        conda activate kipoi-env
         kipoi ls
   # run_coveralls: &run_coveralls
   activate_and_run_tests: &activate_and_run_tests
     run:
       name: Run tests
       command: |
-        export PATH="~/miniconda3/bin:$PATH"
-        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        source activate kipoi-env
+        source ~/.bashrc
+        conda activate kipoi-env
         mkdir test-reports
         $PYTEST --cov=kipoi/ tests/ -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
       no_output_timeout: 15m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ variables:
     run:
       name: Install from dev-requirements-py37.yml
       command: |
+        source ~/.bashrc
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       - *store_test_artifacts
   test-py37-yml:
     machine: # executor type
-      image: ubuntu-1604:202104-01
+      image: ubuntu-2004:202104-01
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ variables:
       command: |
         source ~/.bashrc
         conda env create --name kipoi-env -f dev-requirements-py37.yml
-        conda activate kipoi-env
+        source activate kipoi-env
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -93,7 +93,7 @@ variables:
       name: List kipoi packages
       command: |  
         source ~/.bashrc
-        conda activate kipoi-env
+        source activate kipoi-env
         kipoi ls
   # run_coveralls: &run_coveralls
   activate_and_run_tests: &activate_and_run_tests
@@ -101,7 +101,7 @@ variables:
       name: Run tests
       command: |
         source ~/.bashrc
-        conda activate kipoi-env
+        source activate kipoi-env
         mkdir test-reports
         $PYTEST --cov=kipoi/ tests/ -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
       no_output_timeout: 15m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ variables:
         rm ~/miniconda.sh && \
         ~/miniconda3/bin/conda clean -tipsy && \
         sudo ln -s ~/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-        echo ". ~/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
-        echo "conda activate base" >> ~/.bashrc 
+        echo ". ~/miniconda3/etc/profile.d/conda.sh" >> $BASH_ENV && \
+        echo "conda activate base" >> $BASH_ENV
   update_conda: &update_conda
     run:
       name: Update conda
@@ -54,7 +54,6 @@ variables:
       name: Export shortcuts
       command: |
         # for no good reason the wrong version of pytest is choosen by default...
-        source ~/.bashrc
         echo 'export PYTEST=$(conda info --base)/envs/kipoi-env/bin/pytest' >> $BASH_ENV
   install_from_dev_requirements_py36: &install_from_dev_requirements_py36
     run:
@@ -70,7 +69,6 @@ variables:
     run:
       name: Install from dev-requirements-py37.yml
       command: |  
-        export PATH="~/miniconda3/bin:$PATH"
         conda env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
         pip install -e .
@@ -92,7 +90,6 @@ variables:
     run:
       name: List kipoi packages
       command: |  
-        source ~/.bashrc
         source activate kipoi-env
         kipoi ls
   # run_coveralls: &run_coveralls
@@ -100,9 +97,7 @@ variables:
     run:
       name: Run tests
       command: |
-        source ~/.bashrc
         source activate kipoi-env
-        export PATH="~/miniconda3/bin:$PATH"
         mkdir test-reports
         $PYTEST --cov=kipoi/ tests/ -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
       no_output_timeout: 15m
@@ -128,7 +123,6 @@ variables:
     run:
       name: build python packages
       command: |
-        export PATH="$HOME/miniconda/bin:$PATH"
         source activate kipoi-env
         python setup.py sdist bdist_wheel
   conda_install_twine: &conda_install_twine
@@ -236,8 +230,7 @@ jobs:
       - run:
           name: pip install from TestPyPI
           command: |
-            source ~/.bashrc
-            conda activate kipoi-env
+            source activate kipoi-env
             python -m pip install --user --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple kipoi --verbose
             python -c "import kipoi; print(kipoi.__version__)"
 
@@ -265,7 +258,6 @@ jobs:
       - run:
           name: pip install from PyPI
           command: |
-            source ~/.bashrc
             conda activate kipoi-env
             python -m pip install --user kipoi --verbose
             python -c "import kipoi; print(kipoi.__version__)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ variables:
         source ~/.bashrc
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
         conda env create --name kipoi-env -f dev-requirements-py37.yml
-        source activate kipoi-env
+        conda activate kipoi-env
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
@@ -92,14 +92,16 @@ variables:
     run:
       name: List kipoi packages
       command: |
-        source activate kipoi-env
+        source ~/.bashrc
+        conda activate kipoi-env
         kipoi ls
   # run_coveralls: &run_coveralls
   activate_and_run_tests: &activate_and_run_tests
     run:
       name: Run tests
       command: |
-        source activate kipoi-env
+        source ~/.bashrc
+        conda activate kipoi-env
         mkdir test-reports
         $PYTEST --cov=kipoi/ tests/ -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
       no_output_timeout: 15m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,17 @@ variables:
       name: Install miniconda3
       command: |
         sudo apt-get update && sudo apt-get install -y build-essential libz-dev libcurl3-dev libarchive-dev gcc && \
-        cd $HOME && \
-        wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O $HOME/miniconda.sh && \
-        /usr/bin/bash $HOME/miniconda.sh -b && \
-        export PATH=$HOME/miniconda/bin:$PATH
+        wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
+        /usr/bin/bash ~/miniconda.sh -b && \
+        rm ~/miniconda.sh && \
+        ~/miniconda3/bin/conda clean -tipsy && \
+        sudo ln -s ~/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+        echo ". ~/miniconda3/etc/profile.d/conda.sh" >> ~/.bashrc && \
+        echo "conda activate base" >> ~/.bashrc 
   update_conda: &update_conda
     run:
       name: Update conda
-      command: export PATH="$HOME/miniconda/bin:$PATH" && conda update -n base conda -c anaconda
+      command: source ~/.bashrc && conda update -n base conda -c anaconda
   install_sys_deps: &install_sys_deps
     run:
       name: install build-essential

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,7 @@ variables:
         cd $HOME && \
         wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
         /bin/bash ~/miniconda.sh -b && \
-        rm ~/miniconda.sh && \
         ~/miniconda3/bin/conda clean -tipsy && \  
-
         export PATH=$HOME/miniconda/bin:$PATH
   update_conda: &update_conda
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,8 @@ variables:
       command: |
         source ~/.bashrc
         conda env create --name kipoi-env -f dev-requirements-py37.yml
-        source activate kipoi-env
+        source ~/.bashrc
+        conda activate kipoi-env
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -40,6 +40,7 @@ dependencies:
   - wheel
   - gitpython
   - pip
+  - matplotlib
   - pip:
     - kipoi-utils>=0.3.8
     - kipoi-conda>=0.1.6


### PR DESCRIPTION
The main issue stemmed from running out of memory while installing matplotlib along with installing other packages in dev-requirements-py37.yml. Machine executors in circleci has about 7.5 GB RAM as opposed to the docker executors which has about 4 GB RAM. I think for the sake of homogeneity we should change test-py36-yml to use machine executor as well but for now it is okay. 

PS: I am merging this to master for now but any comment is welcome. 