### PR TITLE
Fixed ci of model repo

### DIFF
--- a/kipoi/cli/source_test.py
+++ b/kipoi/cli/source_test.py
@@ -147,7 +147,7 @@ def test_model(model_name, source_name, env_name, batch_size,
     new_env = os.environ.copy()
     new_env['PATH'] = os.path.dirname(cmd) + os.pathsep + new_env['PATH']
     try:
-        proc = sp.Popen(cmd.extend(args), stdout=sp.PIPE, stderr=sp.PIPE)
+        proc = sp.Popen([cmd].extend(args), stdout=sp.PIPE, stderr=sp.PIPE)
         # returncode, logs = _call_command(cmd, args, use_stdout=True,
         #                                 return_logs_with_stdout=True,
         #                                 env=new_env

--- a/kipoi/cli/source_test.py
+++ b/kipoi/cli/source_test.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import sys
+import subprocess as sp
 from copy import deepcopy
 from math import ceil
 
@@ -145,11 +146,16 @@ def test_model(model_name, source_name, env_name, batch_size,
     # - PATH=$conda_bin:$PATH
     new_env = os.environ.copy()
     new_env['PATH'] = os.path.dirname(cmd) + os.pathsep + new_env['PATH']
-    returncode, logs = _call_command(cmd, args, use_stdout=True,
-                                     return_logs_with_stdout=True,
-                                     env=new_env
-                                     )
-    assert returncode == 0
+    try:
+        proc = sp.Popen(cmd.extend(args), stdout=sp.PIPE, stderr=sp.PIPE)
+        # returncode, logs = _call_command(cmd, args, use_stdout=True,
+        #                                 return_logs_with_stdout=True,
+        #                                 env=new_env
+        #                                 )
+        proc.wait()
+        logs, stderr = proc.communicate()
+    except sp.CalledProcessError as err:
+        logger.error(f"Error: {err.stderr}")
 
     # detect WARNING in the output log
     warn = 0

--- a/kipoi/cli/source_test.py
+++ b/kipoi/cli/source_test.py
@@ -9,7 +9,6 @@ import logging
 import os
 import re
 import sys
-import subprocess as sp
 from copy import deepcopy
 from math import ceil
 
@@ -146,22 +145,17 @@ def test_model(model_name, source_name, env_name, batch_size,
     # - PATH=$conda_bin:$PATH
     new_env = os.environ.copy()
     new_env['PATH'] = os.path.dirname(cmd) + os.pathsep + new_env['PATH']
-    try:
-        proc = sp.Popen([cmd].extend(args), stdout=sp.PIPE, stderr=sp.PIPE)
-        # returncode, logs = _call_command(cmd, args, use_stdout=True,
-        #                                 return_logs_with_stdout=True,
-        #                                 env=new_env
-        #                                 )
-        proc.wait()
-        logs, stderr = proc.communicate()
-    except sp.CalledProcessError as err:
-        logger.error(f"Error: {err.stderr}")
+    returncode, logs = _call_command(cmd, args, use_stdout=True,
+                                     return_logs_with_stdout=True,
+                                     env=new_env
+                                     )
+    assert returncode == 0
 
     # detect WARNING in the output log
     warn = 0
     for line in logs:
-        warn_start = escape_codes[default_log_colors['WARNING']] + \
-            'WARNING' + escape_codes['reset']
+        warn_start = escape_codes.escape_codes[default_log_colors['WARNING']] + \
+            'WARNING' + escape_codes.escape_codes['reset']
         if line.startswith(warn_start):
             logger.error("Warning present: {0}".format(line))
             warn += 1

--- a/kipoi/sources.py
+++ b/kipoi/sources.py
@@ -471,12 +471,12 @@ class LocalSource(Source):
 
                 if not self.config.dependencies.all_installed(verbose=False):
                     import colorlog
-                    print(colorlog.escape_codes['red'])
+                    print(colorlog.escape_codes.escape_codes['red'])
                     print("WARNING: Dependencies for model source '{}' stored at local_path {} not satisfied.: \n---".
                           format(self.name, self._local_path))
                     self.config.dependencies.all_installed(verbose=True)
                     print("---\ninstall or update the missing packages")
-                    print(colorlog.escape_codes['reset'])
+                    print(colorlog.escape_codes.escape_codes['reset'])
                     print("Note: If you don't want to auto_update the model source, \n"
                           "add `auto_update: False` to ~/.kipoi/config.yaml\n")
             else:


### PR DESCRIPTION
This bug manifested in the nightly test of model repo. Check [here](https://app.circleci.com/pipelines/github/kipoi/models/873/workflows/84fdc68e-5ad9-4562-afda-0e62aaa587aa/jobs/2796)
The main error was -
```
ERROR [kipoi.cli.source_test] Model <model-name?> failed: 'module' object is not subscriptable
```
This issue did not show up in any unit test in kipoi repo which shows perhaps not every crucial part of the codebase is coevred by unit tests. 