### PR TITLE
Fixed ci by pinning pyranges

### DIFF
--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -51,7 +51,7 @@ dependencies:
   - gitpython
   - pip
   - pip:
-    - pyranges-0.0.106
+    - pyranges==0.0.104
     - kipoi-utils>=0.3.8
     - kipoi-conda>=0.1.6
     - kipoi-interpret>=0.1.2

--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -51,6 +51,7 @@ dependencies:
   - gitpython
   - pip
   - pip:
+    - pyranges-0.0.106
     - kipoi-utils>=0.3.8
     - kipoi-conda>=0.1.6
     - kipoi-interpret>=0.1.2

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -42,6 +42,7 @@ dependencies:
   - pip
   - matplotlib
   - pip:
+    - pyranges-0.0.106
     - kipoi-utils>=0.3.8
     - kipoi-conda>=0.1.6
     - kipoi-interpret>=0.1.2

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -42,7 +42,7 @@ dependencies:
   - pip
   - matplotlib
   - pip:
-    - pyranges-0.0.106
+    - pyranges==0.0.104
     - kipoi-utils>=0.3.8
     - kipoi-conda>=0.1.6
     - kipoi-interpret>=0.1.2

--- a/dev-requirements-py38.yml
+++ b/dev-requirements-py38.yml
@@ -42,6 +42,7 @@ dependencies:
   - tensorflow=2.4.1
   - keras
   - pip:
+    - pyranges-0.0.106
     - kipoi-veff
     - kipoi-conda
     - kipoi-interpret

--- a/dev-requirements-py38.yml
+++ b/dev-requirements-py38.yml
@@ -42,7 +42,7 @@ dependencies:
   - tensorflow=2.4.1
   - keras
   - pip:
-    - pyranges-0.0.106
+    - pyranges==0.0.104
     - kipoi-veff
     - kipoi-conda
     - kipoi-interpret

--- a/dev-requirements-py39.yml
+++ b/dev-requirements-py39.yml
@@ -40,7 +40,7 @@ dependencies:
   - keras
   - pkgconfig
   - pip:
-    - pyranges-0.0.106
+    - pyranges==0.0.104
     - kipoi-conda
     - kipoi-interpret
     - kipoi-utils

--- a/dev-requirements-py39.yml
+++ b/dev-requirements-py39.yml
@@ -40,6 +40,7 @@ dependencies:
   - keras
   - pkgconfig
   - pip:
+    - pyranges-0.0.106
     - kipoi-conda
     - kipoi-interpret
     - kipoi-utils


### PR DESCRIPTION
pyranges' latest release has a typo which caused all the tests to fail. For now, I have pinned pyranges to use last stable version and have opened an issue [here](https://github.com/biocore-ntnu/pyranges/issues/218). I will revert this change once its fixed.