### PR TITLE
Bugs related to h5py/python version addressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,18 @@ pip install kipoi
 
 ### Known issue: h5py
 
-For systems using python 3.6 and 3.7, kipoi.model.KerasModel and kipoi.model.TensorFlowModel are incompatible with h5py >= 3.*. Please downgrade h5py after
-installing kipoi
+For systems using python 3.6 and 3.7, pretrained kipoi models of type kipoi.model.KerasModel and kipoi.model.TensorflowModel which were saved with h5py <3.* are incompatible with h5py >= 3.*. Please downgrade h5py after installing kipoi
 
 ```bash
 pip install h5py==2.10.0
 ```
-This is not a problem with systems using python 3.8 and 3.9
+This is not a problem with systems using python 3.8 and 3.9.
 More information available [here](https://github.com/tensorflow/tensorflow/issues/44467)
 
 For systems using python 3.8 and 3.9, it is necessary to install hdf5 and pkgconfig prior to installing kipoi.
 
 ```bash
 conda install --yes -c conda-forge hdf5 pkgconfig
-```
-
-Install Kipoi using [pip](https://pip.pypa.io/en/stable/):
-```bash
-pip install kipoi
 ```
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -38,7 +38,24 @@ This repository implements a python package and a command-line interface (CLI) t
 Kipoi requires [conda](https://conda.io/) to manage model dependencies.
 Make sure you have either anaconda ([download page](https://www.anaconda.com/download/)) or miniconda ([download page](https://conda.io/miniconda.html)) installed. If you are using OSX, see [Installing python on OSX](http://kipoi.org/docs/using/04_Installing_on_OSX). Maintained python versions: >=3.6<=3.9. 
 
-For systems using python 3.8 and 3.9, is necessary to install hdf5 and pkgconfig prior to installing kipoi.
+
+Install Kipoi using [pip](https://pip.pypa.io/en/stable/):
+```bash
+pip install kipoi
+```
+
+### Known issue: h5py
+
+For systems using python 3.6 and 3.7, kipoi.model.KerasModel and kipoi.model.TensorFlowModel are incompatible with h5py >= 3.*. Please downgrade h5py after
+installing kipoi
+
+```bash
+pip install h5py==2.10.0
+```
+This is not a problem with systems using python 3.8 and 3.9
+More information available [here](https://github.com/tensorflow/tensorflow/issues/44467)
+
+For systems using python 3.8 and 3.9, it is necessary to install hdf5 and pkgconfig prior to installing kipoi.
 
 ```bash
 conda install --yes -c conda-forge hdf5 pkgconfig

--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -17,7 +17,7 @@ dependencies:
   - pytest-cov>=2.6.1
   - deprecation>=2.0.6
   #- coveralls
-  - h5py
+  - h5py=2.10.0 # h5py >= 3.* is incompatible with keras 
   - coveralls
   - scipy>=1.0.0
   - attrs>=18.2.0

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -11,7 +11,7 @@ dependencies:
   - pytest>=3.3.1
   - pytest-cov>=2.6.1
   #- coveralls
-  - h5py
+  - h5py=2.10.0 # h5py >= 3.* is incompatible with keras 
   - scipy>=1.0.0
   - pybigwig>=0.3.10
   - pybedtools>=0.7.10

--- a/kipoi/readers.py
+++ b/kipoi/readers.py
@@ -6,6 +6,7 @@ import numpy as np
 from kipoi_utils.external.flatten_json import unflatten_list
 from abc import abstractmethod
 
+from distutils.version import LooseVersion
 
 class Reader(object):
 
@@ -26,6 +27,10 @@ def _h5py_dataset_iterator(g, prefix=''):
         item = g[key]
         path = '{}/{}'.format(prefix, key)
         if isinstance(item, h5py.Dataset):  # test for dataset
+            if h5py.__version__ > LooseVersion('2.10.0'):
+                string_type = h5py.check_string_dtype(item.dtype)
+                if (string_type is not None) and (string_type.encoding == "utf-8"):
+                    item = item.asstr()[:]
             yield (path, item)
         elif isinstance(item, h5py.Group):  # test for group (go down)
             for x in _h5py_dataset_iterator(item, path):


### PR DESCRIPTION
For python 3.6 and 3.7 h5py version must be < 3.*, otherwise pretrained models of type kipoi.model.KerasModel and kipoi.model.TensorflowModel can not be loaded. 
A related bug report: [here](https://github.com/tensorflow/tensorflow/issues/44467)
