### PR TITLE
add support for writing parquet files

### DIFF
--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -41,6 +41,7 @@ dependencies:
   - keras>=2.2.4
   # for plugins (double check)
   - fastparquet
+  - pyarrow
   - zarr 
   - numcodecs
   # singularity

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -29,6 +29,7 @@ dependencies:
   - keras>=2.2.4
   # for plugins (double check)
   - fastparquet
+  - pyarrow
   - zarr 
   - numcodecs
   - tinydb>=3.12.2

--- a/dev-requirements-py38.yml
+++ b/dev-requirements-py38.yml
@@ -24,6 +24,7 @@ dependencies:
   - pandas=1.3.1
   - pillow=8.3.1
   - pip=21.2.1
+  - pyarrow
   - pybedtools=0.8.2
   - pybigwig=0.3.18
   - pyfaidx=0.6.1

--- a/dev-requirements-py39.yml
+++ b/dev-requirements-py39.yml
@@ -22,6 +22,7 @@ dependencies:
   - pandas
   - pillow
   - pip
+  - pyarrow
   - pybedtools
   - pybigwig
   - pyfaidx

--- a/kipoi/writers.py
+++ b/kipoi/writers.py
@@ -182,7 +182,7 @@ class ParquetDirBatchWriter(BatchWriter):
     ):
         if chunk_size is None:
             # 10^6 rows per file by default
-            chunk_size = 10000
+            chunk_size = 1000000
 
         from pathlib import Path
         import uuid

--- a/kipoi/writers.py
+++ b/kipoi/writers.py
@@ -176,10 +176,14 @@ class ParquetDirBatchWriter(BatchWriter):
     def __init__(
             self,
             file_path,
-            chunk_size=1000000,  # 10^6 rows per file by default
+            chunk_size=None,
             nested_sep="/",
             append=True,
     ):
+        if chunk_size is None:
+            # 10^6 rows per file by default
+            chunk_size = 10000
+
         from pathlib import Path
         import uuid
         from datetime import datetime
@@ -230,9 +234,12 @@ class ParquetFileBatchWriter(BatchWriter):
     def __init__(
             self,
             file_path,
-            chunk_size=10000,
+            chunk_size=None,
             nested_sep="/",
     ):
+        if chunk_size is None:
+            chunk_size = 10000
+
         # optional import of pyarrow
         import pyarrow as pa
         import pyarrow.parquet as pq

--- a/kipoi/writers.py
+++ b/kipoi/writers.py
@@ -198,9 +198,9 @@ class ParquetDirBatchWriter(BatchWriter):
 
         if self.file_path.exists():
             if not append:
-                raise FileExistsError("'{}' already exists!")
+                raise FileExistsError(f"'{file_path}' already exists!")
             if not self.file_path.is_dir():
-                raise FileExistsError("'{}' is no directory!")
+                raise FileExistsError(f"'{file_path}' is no directory!")
         else:
             self.file_path.mkdir()
 
@@ -261,7 +261,7 @@ class ParquetFileBatchWriter(BatchWriter):
         self.pq_writer = None
 
         if self.file_path.exists():
-            raise FileExistsError("'{}' already exists!")
+            raise FileExistsError(f"'{file_path}' already exists!")
 
     def batch_write(self, batch):
         df = pd.DataFrame(flatten_batch(batch, nested_sep=self.nested_sep))

--- a/kipoi/writers.py
+++ b/kipoi/writers.py
@@ -275,7 +275,7 @@ class ParquetFileBatchWriter(BatchWriter):
 
     def _flush(self):
         df_all = pd.concat(self.write_buffer, axis=0)
-        table = self.pa.Table.from_pandas(df_all)
+        table = self.pa.Table.from_pandas(df_all, preserve_index=False)
 
         if self.pq_writer is None:
             self.pq_writer = self.pq.ParquetWriter(self.file_path, table.schema)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ test_requirements = [
     "wheel",
     "jedi",
     "epc",
+    "pyarrow",
     "pytest>=3.3.1",
     "pytest-xdist",  # running tests in parallel
     "pytest-pep8",  # see https://github.com/kipoi/kipoi/issues/91

--- a/tests/test_161_writers.py
+++ b/tests/test_161_writers.py
@@ -24,7 +24,6 @@ import pandas as pd
 from kipoi.specs import DataLoaderSchema, ArraySchema, MetadataStruct, MetadataType
 from collections import OrderedDict
 
-from kipoi.writers import ParquetFileBatchWriter
 from kipoi_utils.utils import get_subsuffix
 import zarr
 


### PR DESCRIPTION
This PR adds support for writing parquet files.
In particular, it adds two additional parquet writer implementations:
- `ParquetFileBatchWriter`: Writes to a single parquet file and depends on PyArrow.
- `ParquetDirBatchWriter`: Writes a directory of parquet files using `pandas.to_parquet()`. Supports both PyArrow and fastparquet. This implementation is predestined for multi-processing / asynchronous writing since no file-locking is necessary for it. Nevertheless, I'm not sure yet how Kipoi would take advantage of that.

My very long-term goal is that we directly provide schemas as Arrow schemas to be able to pass them around cross-language without any kind of conversion/serialization:
https://arrow.apache.org/docs/python/api/datatypes.html
This PR is the first step in that direction.
Future work:
- Explicit Arrow schema conversion
- Use Tensor type for arrays (https://github.com/apache/arrow/pull/8510)
- Implement struct/list types in Pandas (https://github.com/pandas-dev/pandas/pull/45745), e.g. for GenomicRange