### PR TITLE
Fixes for python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,16 +83,6 @@ variables:
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
-  install_from_dev_requirements_py310: &install_from_dev_requirements_py310
-    run:
-      name: Install from dev-requirements-py310.yml
-      command: |
-        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        conda env create --name kipoi-env -f dev-requirements-py310.yml
-        source activate kipoi-env
-        pip install -e .
-        git lfs install
-        # ln -s /opt/conda/bin/python /usr/bin/python
   install_kipoi: &install_kipoi
     run:
       name: Install Kipoi
@@ -130,14 +120,6 @@ variables:
         $PYTEST --cov=kipoi/ tests/ -k "not legacy" -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
       no_output_timeout: 30m
   activate_and_run_tests_py39: &activate_and_run_tests_py39
-    run:
-      name: Run tests
-      command: |
-        source activate kipoi-env
-        mkdir test-reports
-        $PYTEST --cov=kipoi/ tests/ -k "not legacy" -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
-      no_output_timeout: 30m
-  activate_and_run_tests_py310: &activate_and_run_tests_py310
     run:
       name: Run tests
       command: |
@@ -263,24 +245,6 @@ jobs:
       # - *activate_and_run_coveralls
       - *store_test_results
       - *store_test_artifacts
-  test-py310-yml:
-    machine: # executor type
-      image: ubuntu-2004:202104-01
-    resource_class: medium
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - *install_conda
-      # - *update_conda # No need to use this anymore since the latest miniconda is installed always
-      # - *install_sys_deps # Installed in install_conda step
-      - *install_from_dev_requirements_py310
-      - *install_singularity
-      - *export_shortcuts
-      - *activate_and_kipoi_ls
-      - *activate_and_run_tests_py310
-      # - *activate_and_run_coveralls
-      - *store_test_results
-      - *store_test_artifacts
 
   build-deploy-docs:
     docker:
@@ -380,7 +344,6 @@ workflows:
       - test-py37-yml
       - test-py38-yml
       - test-py39-yml
-      - test-py310-yml
       - build-deploy-docs:
           requires:
             - test-py36-yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,16 @@ variables:
         pip install -e .
         git lfs install
         # ln -s /opt/conda/bin/python /usr/bin/python
+  install_from_dev_requirements_py310: &install_from_dev_requirements_py310
+    run:
+      name: Install from dev-requirements-py310.yml
+      command: |
+        echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
+        conda env create --name kipoi-env -f dev-requirements-py310.yml
+        source activate kipoi-env
+        pip install -e .
+        git lfs install
+        # ln -s /opt/conda/bin/python /usr/bin/python
   install_kipoi: &install_kipoi
     run:
       name: Install Kipoi
@@ -120,6 +130,14 @@ variables:
         $PYTEST --cov=kipoi/ tests/ -k "not legacy" -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
       no_output_timeout: 30m
   activate_and_run_tests_py39: &activate_and_run_tests_py39
+    run:
+      name: Run tests
+      command: |
+        source activate kipoi-env
+        mkdir test-reports
+        $PYTEST --cov=kipoi/ tests/ -k "not legacy" -p no:sugar --no-cov-on-fail --junitxml=test-reports/junit.xml
+      no_output_timeout: 30m
+  activate_and_run_tests_py310: &activate_and_run_tests_py310
     run:
       name: Run tests
       command: |
@@ -245,6 +263,24 @@ jobs:
       # - *activate_and_run_coveralls
       - *store_test_results
       - *store_test_artifacts
+  test-py310-yml:
+    machine: # executor type
+      image: ubuntu-2004:202104-01
+    resource_class: medium
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - *install_conda
+      # - *update_conda # No need to use this anymore since the latest miniconda is installed always
+      # - *install_sys_deps # Installed in install_conda step
+      - *install_from_dev_requirements_py310
+      - *install_singularity
+      - *export_shortcuts
+      - *activate_and_kipoi_ls
+      - *activate_and_run_tests_py310
+      # - *activate_and_run_coveralls
+      - *store_test_results
+      - *store_test_artifacts
 
   build-deploy-docs:
     docker:
@@ -344,6 +380,7 @@ workflows:
       - test-py37-yml
       - test-py38-yml
       - test-py39-yml
+      - test-py310-yml
       - build-deploy-docs:
           requires:
             - test-py36-yml

--- a/dev-requirements-py310.yml
+++ b/dev-requirements-py310.yml
@@ -16,6 +16,7 @@ dependencies:
   - gitpython
   - pip
   - pip:
+    - zarr
     - pytest
     - pytest-cov
     - tensorflow

--- a/dev-requirements-py310.yml
+++ b/dev-requirements-py310.yml
@@ -6,41 +6,24 @@ channels:
 dependencies:
   - python=3.10
   - bedtools
-  - cookiecutter
   - cython
-  - cyvcf2
-  - fastparquet
-  - git
-  - git-lfs
-  - h5py
   - hdf5
-  - htslib
-  - matplotlib
-  - numcodecs
+  - h5py
   - numpy
   - pandas
-  - pillow
   - pip
-  - pyarrow
-  - pybedtools
-  - pybigwig
-  - pyfaidx
-  - pysam
-  - pytest
-  - pytest-cov
-  - pyvcf
-  - pyyaml
-  - scikit-learn
-  - scipy
-  - setuptools
-  - wheel
-  - zarr
-  - tensorflow
-  - keras
-  - pkgconfig
   - pip:
-    - pytorch # Not available in conda yet
+    - pytest
+    - tensorflow
+    - keras
+    - scikit-learn
+    - pkgconfig
     - kipoi-conda
     - kipoi-interpret
     - kipoi-utils
     - kipoiseq
+    - cyvcf2
+    - pybedtools
+    - pybigwig
+    - pyfaidx
+

--- a/dev-requirements-py310.yml
+++ b/dev-requirements-py310.yml
@@ -16,6 +16,7 @@ dependencies:
   - gitpython
   - pip
   - pip:
+    - pyarrow
     - zarr
     - pytest
     - pytest-cov

--- a/dev-requirements-py310.yml
+++ b/dev-requirements-py310.yml
@@ -17,6 +17,7 @@ dependencies:
   - pip
   - pip:
     - pytest
+    - pytest-cov
     - tensorflow
     - keras
     - scikit-learn

--- a/dev-requirements-py310.yml
+++ b/dev-requirements-py310.yml
@@ -11,6 +11,9 @@ dependencies:
   - h5py
   - numpy
   - pandas
+  - git
+  - git-lfs
+  - gitpython
   - pip
   - pip:
     - pytest

--- a/kipoi/kipoidescriptionhelper.py
+++ b/kipoi/kipoidescriptionhelper.py
@@ -1,4 +1,5 @@
-from collections import Mapping, OrderedDict, Sequence
+from collections.abc import Mapping, Sequence
+from collections import OrderedDict
 from dataclasses import dataclass, field
 import os
 import logging

--- a/kipoi/kipoimodeldescription.py
+++ b/kipoi/kipoimodeldescription.py
@@ -1,4 +1,5 @@
-from collections import Mapping, OrderedDict, Sequence
+from collections.abc import Mapping, Sequence
+from collections import OrderedDict
 from dataclasses import dataclass, field
 import os
 import logging

--- a/kipoi/metadata.py
+++ b/kipoi/metadata.py
@@ -3,7 +3,7 @@
 All classes inherit from `collections.abc.Mapping` which allows to use
 `kipoi.data_utils.numpy_collate` on them (e.g. they behave as a dictionary).
 """
-from collections import Mapping
+from collections.abc import Mapping
 from kipoi_utils.data_utils import numpy_collate, numpy_collate_concat
 
 import pandas as pd

--- a/kipoi/model.py
+++ b/kipoi/model.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from io import open
 
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 import sys
 import os
 import yaml


### PR DESCRIPTION
More fixes with collections and a preliminary conda environment. A new sets of tests have not been added in ci because for now pytorch is not available in python 3.10.  