### PR TITLE
Fixed ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ variables:
 jobs:
   test-py36-yml:
     machine: # executor type
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
     resource_class: medium
     working_directory: ~/repo
     steps:
@@ -211,7 +211,7 @@ jobs:
       - *store_test_artifacts
   test-py37-yml:
     machine: # executor type
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
     resource_class: medium
     working_directory: ~/repo
     steps:
@@ -229,7 +229,7 @@ jobs:
       - *store_test_artifacts
   test-py38-yml:
     machine: # executor type
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
     resource_class: medium
     working_directory: ~/repo
     steps:
@@ -247,7 +247,7 @@ jobs:
       - *store_test_artifacts
   test-py39-yml:
     machine: # executor type
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
     resource_class: medium
     working_directory: ~/repo
     steps:
@@ -265,7 +265,7 @@ jobs:
       - *store_test_artifacts
   test-py310-yml:
     machine: # executor type
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
     resource_class: medium
     working_directory: ~/repo
     steps:
@@ -310,7 +310,7 @@ jobs:
 
   test-deploy-pypi:
     machine: # executor type
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
     resource_class: medium
     working_directory: ~/repo
     steps:
@@ -340,7 +340,7 @@ jobs:
 
   productive-deploy-pypi:
     machine: # executor type
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
     resource_class: medium
     working_directory: ~/repo
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ variables:
     run:
       name: Update conda
       command: conda update -n base conda -c anaconda
+  install_mamba: &install_mamba
+    run:
+      name: Install mamba
+      command: conda install mamba -y -n base -c conda-forge
   install_sys_deps: &install_sys_deps
     run:
       name: install build-essential
@@ -27,7 +31,6 @@ variables:
       command: |
         source activate kipoi-env
         conda install --yes -c conda-forge singularity
-
   install_kipoi_plugins: &install_kipoi_plugins
     run:
       name: Install kipoi plugins
@@ -48,7 +51,7 @@ variables:
       name: Install from dev-requirements-py36.yml
       command: |
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        conda env create --name kipoi-env -f dev-requirements-py36.yml
+        mamba env create --name kipoi-env -f dev-requirements-py36.yml
         source activate kipoi-env
         pip install -e .
         git lfs install
@@ -199,6 +202,7 @@ jobs:
     steps:
       - checkout
       - *install_conda
+      - *install_mamba
       # - *update_conda # No need to use this anymore since the latest miniconda is installed always
       # - *install_sys_deps # Installed in install_conda step
       - *install_from_dev_requirements_py36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ variables:
       name: Install from dev-requirements-py37.yml
       command: |  
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        conda env create --name kipoi-env -f dev-requirements-py37.yml
+        mamba env create --name kipoi-env -f dev-requirements-py37.yml
         source activate kipoi-env
         pip install -e .
         git lfs install
@@ -71,7 +71,7 @@ variables:
       name: Install from dev-requirements-py38.yml
       command: |
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        conda env create --name kipoi-env -f dev-requirements-py38.yml
+        mamba env create --name kipoi-env -f dev-requirements-py38.yml
         source activate kipoi-env
         pip install -e .
         git lfs install
@@ -81,7 +81,7 @@ variables:
       name: Install from dev-requirements-py39.yml
       command: |
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        conda env create --name kipoi-env -f dev-requirements-py39.yml
+        mamba env create --name kipoi-env -f dev-requirements-py39.yml
         source activate kipoi-env
         pip install -e .
         git lfs install
@@ -91,7 +91,7 @@ variables:
       name: Install from dev-requirements-py310.yml
       command: |
         echo 'export CI_JOB_PY_YAML="$CI_JOB_PY_YAML"' >> $BASH_ENV
-        conda env create --name kipoi-env -f dev-requirements-py310.yml
+        mamba env create --name kipoi-env -f dev-requirements-py310.yml
         source activate kipoi-env
         pip install -e .
         git lfs install
@@ -221,6 +221,7 @@ jobs:
     steps:
       - checkout
       - *install_conda
+      - *install_mamba
       # - *update_conda # No need to use this anymore since the latest miniconda is installed always
       # - *install_sys_deps # Installed in install_conda step
       - *install_from_dev_requirements_py37
@@ -239,6 +240,7 @@ jobs:
     steps:
       - checkout
       - *install_conda
+      - *install_mamba
       # - *update_conda # No need to use this anymore since the latest miniconda is installed always
       # - *install_sys_deps # Installed in install_conda step
       - *install_from_dev_requirements_py38
@@ -257,6 +259,7 @@ jobs:
     steps:
       - checkout
       - *install_conda
+      - *install_mamba
       # - *update_conda # No need to use this anymore since the latest miniconda is installed always
       # - *install_sys_deps # Installed in install_conda step
       - *install_from_dev_requirements_py39
@@ -275,6 +278,7 @@ jobs:
     steps:
       - checkout
       - *install_conda
+      - *install_mamba
       # - *update_conda # No need to use this anymore since the latest miniconda is installed always
       # - *install_sys_deps # Installed in install_conda step
       - *install_from_dev_requirements_py310
@@ -320,6 +324,7 @@ jobs:
     steps:
       - checkout
       - *install_conda
+      - *install_mamba
       # - *update_conda # No need to use this anymore since the latest miniconda is installed always
       # - *install_sys_deps # Installed in install_conda step
       - *install_from_dev_requirements_py39
@@ -350,6 +355,7 @@ jobs:
     steps:
       - checkout
       - *install_conda
+      - *install_mamba
       # - *update_conda # No need to use this anymore since the latest miniconda is installed always
       # - *install_sys_deps # Installed in install_conda step
       - *install_from_dev_requirements_py39

--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -12,14 +12,9 @@ dependencies:
   - numpy>=1.13.0
   - pandas
   - pytest>=3.3.1
-  - pytest-xdist
-  - pytest-sugar
   - pytest-cov>=2.6.1
-  - deprecation>=2.0.6
   - h5py=2.10.0 # h5py >= 3.* is incompatible with keras 
   - coveralls
-  - scipy>=1.0.0
-  - attrs>=18.2.0
   - matplotlib
   - tinydb>=3.12.2
   # Bio


### PR DESCRIPTION
- Replaced conda with mamba for installing kipoi-dev environment. The reason for the switch is - circleci free account only gives an hour of runtime and 7.5 GB RAM. Replacing conda with mamba makes installing the base environment faster and is not going out of memory like conda.
- Also updated the machine image to current 
   