### PR TITLE
Attempt to fix flaky tests

### DIFF
--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -17,7 +17,7 @@ dependencies:
   - pyvcf>=0.6.8
   - pysam>=0.14.0
   - pyfaidx>=0.5.5.2
-  - cython
+  - cython=0.29.23
   - cyvcf2>=0.8.4
   - bedtools>=2.27.1
   - htslib>=1.7
@@ -29,7 +29,7 @@ dependencies:
   - keras>=2.2.4
   # for plugins (double check)
   - fastparquet
-  - pyarrow
+  - pyarrow=7.0.0
   - zarr 
   - numcodecs
   - tinydb>=3.12.2

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -17,7 +17,7 @@ dependencies:
   - pyvcf>=0.6.8
   - pysam>=0.14.0
   - pyfaidx>=0.5.5.2
-  - cython=0.29.23
+  - cython
   - cyvcf2>=0.8.4
   - bedtools>=2.27.1
   - htslib>=1.7


### PR DESCRIPTION
For some reason, tests involving pyarrow have been flaky only in `python=3.7` environment. I checked that on occasions when these tests failed, somehow pyarrow 0.11 was installed which is rather old. For now, I am pinning pyarrow to its current version `7.0.0`. For now, the tests are passing and I will continue to monitor the flakyness.