### PR TITLE
Fixed CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,8 +204,7 @@ jobs:
       - *export_shortcuts
       - *activate_and_kipoi_ls
       - *activate_and_run_tests
-      # - coveralls/upload
-      # - *activate_and_run_coveralls
+      - *activate_and_run_coveralls
       - *store_test_results
       - *store_test_artifacts
   test-36:
@@ -244,7 +243,6 @@ jobs:
       - *export_shortcuts
       - *activate_and_kipoi_ls
       - *activate_and_run_tests_py367
-      - *activate_and_run_coveralls
       - *store_test_results
       - *store_test_artifacts
   build-deploy-docs:

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -21,7 +21,6 @@ dependencies:
   - cyvcf2>=0.8.4
   - bedtools>=2.27.1
   - htslib>=1.7
-  - coveralls
   # ML
   - scikit-learn>=0.19.1,<=0.22
   - tensorflow==1.13.1

--- a/dev-requirements.yml
+++ b/dev-requirements.yml
@@ -10,6 +10,7 @@ dependencies:
   - pytorch
   - pytest
   - pytest-cov
+  - coveralls
   - pip
   - pip:
     - sklearn

--- a/example/models/pyt/dataloader.yaml
+++ b/example/models/pyt/dataloader.yaml
@@ -21,7 +21,7 @@ info:
   doc: Dataloader for the DeepSEA model.
 dependencies:
   conda:
-    - python=3.5
+    - python=3.7
     - numpy
     - pandas
   pip:

--- a/example/models/shared/envs/kipoi-py3-keras1.2.yaml
+++ b/example/models/shared/envs/kipoi-py3-keras1.2.yaml
@@ -8,7 +8,7 @@ dependencies:
 - cyvcf2
 - pybedtools
 - pysam
-- python=3.5
+- python=3.7
 - h5py
 - genomelake
 - numpy

--- a/example/models/shared/envs/kipoi-py3-keras1.2_bad.yaml
+++ b/example/models/shared/envs/kipoi-py3-keras1.2_bad.yaml
@@ -8,7 +8,7 @@ dependencies:
 - cyvcf2
 - pybedtools
 - pysam
-- python=3.5
+- python=3.7
 - h5py
 - genomelake
 - numpy

--- a/example/models/tal1_model/dataloader.yaml
+++ b/example/models/tal1_model/dataloader.yaml
@@ -22,7 +22,7 @@ info:
 dependencies:
   conda:
     - bioconda::pybedtools
-    - python=3.5
+    - python=3.7
     - numpy
     - pandas
     - cython

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,1 +1,12 @@
+import sys
+
+import pytest
+
 install_req = False
+
+
+pythonversion = pytest.mark.skipif(
+    sys.version_info.major == 3 and sys.version_info.minor < 8, \
+         reason="These tests are either repeated in tests/legacy/test_cli_examples.py \
+             or not supported >=3.8"
+)

--- a/tests/test_10_KipoiModel.py
+++ b/tests/test_10_KipoiModel.py
@@ -2,8 +2,8 @@
 """
 import pytest
 import kipoi
-import sys
-import config
+
+from config import install_req, pythonversion
 import kipoi
 from kipoi.specs import Dependencies
 from kipoi.pipeline import install_model_requirements
@@ -14,17 +14,12 @@ from tensorflow import keras
 
 EXAMPLES_TO_RUN = ["pyt", "upgradedkeras"]
 # TODO - finish the unit-test
-INSTALL_REQ = config.install_req
+INSTALL_REQ = install_req
 
-
+@pythonversion
 @pytest.mark.parametrize("example", EXAMPLES_TO_RUN)
 def test_load_model(example):
     example_dir = "example/models/{0}".format(example)
-
-    if example in {"rbp", "iris_model_template"} and sys.version_info[0] == 2:
-        pytest.skip("example not supported on python 2 ")
-    if example == "upgradedkeras" and sys.version_info.major == 3 and sys.version_info.minor < 8:
-        pytest.skip("example is only supported >= python 3.8 ")
 
     if INSTALL_REQ:
         install_model_requirements(example_dir, "dir")

--- a/tests/test_15_TensorFlow2Model.py
+++ b/tests/test_15_TensorFlow2Model.py
@@ -2,38 +2,31 @@
 """
 import os
 import subprocess
-import sys
 
 import numpy as np
 import pytest
 
+from config import pythonversion
 import kipoi
 from kipoi.model import TensorFlow2Model
 
-
+@pythonversion
 def test_loading():
-    if sys.version_info.major == 3 and sys.version_info.minor < 8:
-        pytest.skip("example is only supported >= python 3.8 ")
-
     savedmodel_path = "example/models/iris_tensorflow2/model_files/"
     a = TensorFlow2Model(savedmodel_path=savedmodel_path)
     o = a.predict_on_batch([np.ones((3, 4))])
     assert o.shape == (1, 3, 3)
 
+@pythonversion
 def test_loading_from_kipoi():
-    if sys.version_info.major == 3 and sys.version_info.minor < 8:
-        pytest.skip("example is only supported >= python 3.8 ")
-
     m = kipoi.get_model("example/models/iris_tensorflow2", source="dir")
     o = m.predict_on_batch([np.ones((3, 4))])
     assert o.shape == (1, 3, 3)
     
+@pythonversion
 def test_test_example(tmpdir):
     """kipoi test ..., add also output file writing
     """
-    if sys.version_info.major == 3 and sys.version_info.minor < 8:
-        pytest.skip("example is only supported >= python 3.8 ")
-
     args = ["python", "./kipoi/__main__.py", "test",
             "--batch_size=4",
             "--keep_metadata",

--- a/tests/test_26_cli_examples.py
+++ b/tests/test_26_cli_examples.py
@@ -2,13 +2,12 @@
 """
 import os
 import subprocess
-import sys
 
 import pandas as pd
 import pytest
 import yaml
 
-import config
+from config import install_req, pythonversion
 # import filecmp
 import kipoi
 import kipoi_conda
@@ -18,11 +17,7 @@ from kipoi.readers import HDF5Reader
 from utils import cp_tmpdir
 
 
-pythonversion = pytest.mark.skipif(
-    sys.version_info.major == 3 and sys.version_info.minor < 8, reason="These tests are repeated in tests/legacy/test_cli_examples.py"
-)
-
-if config.install_req:
+if install_req:
     INSTALL_FLAG = "--install_req"
 else:
     INSTALL_FLAG = ""
@@ -91,8 +86,6 @@ def test_postproc_cli_fail():
 def test_predict_activation_example(example, tmpdir):
     """Kipoi predict --layer=x with a specific output layer specified
     """
-    if example in {"rbp", "non_bedinput_model", "iris_model_template"} and sys.version_info[0] == 2:
-        pytest.skip("rbp example not supported on python 2 ")
     if example in {'kipoi_dataloader_decorator'}:
         pytest.skip("Automatically-dowloaded input files skipped for prediction")
 
@@ -146,8 +139,6 @@ def test_kipoi_pull():
 def test_kipoi_info():
     """Test that pull indeed pulls the right model
     """
-    if sys.version_info[0] == 2:
-        pytest.skip("example not supported on python 2 ")
     args = ["python", os.path.abspath("./kipoi/__main__.py"), "info",
             "rbp_eclip/AARS"]
     returncode = subprocess.call(args=args)

--- a/tests/test_26_cli_examples.py
+++ b/tests/test_26_cli_examples.py
@@ -17,6 +17,11 @@ from kipoi.env_db import EnvDbEntry
 from kipoi.readers import HDF5Reader
 from utils import cp_tmpdir
 
+
+pythonversion = pytest.mark.skipif(
+    sys.version_info.major == 3 and sys.version_info.minor < 8, reason="These tests are repeated in tests/legacy/test_cli_examples.py"
+)
+
 if config.install_req:
     INSTALL_FLAG = "--install_req"
 else:
@@ -30,7 +35,7 @@ predict_activation_layers = {
 }
 ACTIVATION_EXAMPLES = ['pyt']
 
-
+@pythonversion
 def test_cli_get_example(tmpdir):
     """kipoi test ..., add also output file writing
     """
@@ -46,7 +51,7 @@ def test_cli_get_example(tmpdir):
     assert os.path.exists(os.path.join(outdir, "targets_file"))
 
 
-
+@pythonversion
 def test_cli_test_expect(tmpdir):
     """kipoi test - check that the expected predictions also match
     """
@@ -68,7 +73,7 @@ def test_cli_test_expect(tmpdir):
                                      "-e", os.path.join(example_dir, "expected.pred.h5"),
                                      example_dir])
 
-
+@pythonversion
 def test_postproc_cli_fail():
     """kipoi test ...
     """
@@ -81,6 +86,7 @@ def test_postproc_cli_fail():
     returncode = subprocess.call(args=args)
     assert returncode > 0
 
+@pythonversion
 @pytest.mark.parametrize("example", ACTIVATION_EXAMPLES)
 def test_predict_activation_example(example, tmpdir):
     """Kipoi predict --layer=x with a specific output layer specified
@@ -122,7 +128,7 @@ def test_predict_activation_example(example, tmpdir):
         with kipoi_utils.utils.cd(os.path.join(example_dir, "example_files")):
             kipoi.cli.main.cli_predict("predict", args[3:])
 
-
+@pythonversion
 def test_kipoi_pull():
     """Test that pull indeed pulls the right model
     """
@@ -136,7 +142,7 @@ def test_kipoi_pull():
 
     kipoi.cli.main.cli_pull("pull", ["rbp_eclip/AARS"])
 
-
+@pythonversion
 def test_kipoi_info():
     """Test that pull indeed pulls the right model
     """
@@ -147,7 +153,7 @@ def test_kipoi_info():
     returncode = subprocess.call(args=args)
     assert returncode == 0
 
-
+@pythonversion
 def assert_rec(a, b):
     if isinstance(a, dict):
         assert set(a.keys()) == set(b.keys())
@@ -205,7 +211,7 @@ class PseudoConda:
         else:
             raise Exception("Failed")
 
-
+@pythonversion
 def test_kipoi_env_create_cleanup_remove(tmpdir, monkeypatch):
     from kipoi.cli.env import cli_create, cli_cleanup, cli_remove, cli_get, cli_get_cli, cli_list
     tempfile = os.path.join(str(tmpdir), "envs.json")
@@ -325,7 +331,7 @@ def test_kipoi_env_create_cleanup_remove(tmpdir, monkeypatch):
     kipoi.config._env_db_path = old_env_db_path
     kipoi.env_db.reload_model_env_db()
 
-
+@pythonversion
 def test_kipoi_env_create_all(tmpdir, monkeypatch):
     from kipoi.cli.env import cli_create
     conda = PseudoConda(tmpdir)
@@ -337,13 +343,14 @@ def test_kipoi_env_create_all(tmpdir, monkeypatch):
     # pretend to run the CLI
     cli_create(*process_args(args))
 
-
+@pythonversion
 def test_kipoi_env_create_all_dry_run():
     from kipoi.cli.env import cli_create
     args = ["python", os.path.abspath("./kipoi/__main__.py"), "env", "create", "all", "--dry-run"]
     # pretend to run the CLI
     cli_create(*process_args(args))
 
+@pythonversion
 def test_kipoi_datalaoder_from_cli(tmp_path):
     tmp_output_dir = tmp_path / "output"
     tmp_output_dir.mkdir()


### PR DESCRIPTION
Closes: #675 

I have added a skip decorator for tests in `test_26_cli_examples.py` if python < 3.8. These type of cli  tests are already present under tests/legacy/test_cli_examples.py which exclusively get tested with python <=3.7. Also, since python 3.6 is EOLed. I think it is not necessary to check errors which I cant reproduce locally and happens only on circleci for older python versions. 