### PR TITLE
Fixes to circumvent out of memory error during conda environment creation with python=3.10

### DIFF
--- a/dev-requirements.yml
+++ b/dev-requirements.yml
@@ -1,6 +1,5 @@
 name: kipoi-dev
 channels:
-  - pytorch
   - conda-forge
   - bioconda
   - defaults


### PR DESCRIPTION
Closes: #681 

This is not a new error and in the past these are the three solutions I came up to circumvent conda related oom errors

1. Using machine executors instead of docker executor as the amount of RAM was ~1.5 times
2. Using libmamba solver since mamba uses less memory than conda.
3. Using slimmer (~2-3 times) smaller singularity images

This time, obviously none of these worked. I also noticed resolution of kipoi-env environment with python=3.10 takes about twice as much time as with python=3.8/3.9 but they use the same environment file dev-requirements.yml. I briefly looked into conda-metachannel as decribed [here](https://www.anaconda.com/blog/understanding-and-improving-condas-performance). But, it is an unmaintained project as of now and I would have to host it myself.  

I decided to try out pinning package versions from a working nightly test and it seemed to help. The only issue I have with that is I envision the ngihtly tests to check kipoi with the ever changing python dependency world. If I pin versions, sooner or later newer versions will come out and no one will know whether kipoi is still compatible with the outside world. So, I have chosen a middle ground - using `>=`

Another strange thing I noticed is if pytorch is getting installed from pytorch channel as per official recommendation, it downloads the gpu version and cudatoolkit by default.  Now, both cudatoolkit and pytorch compiled for gpu are quite big in size and unnecessary for CI since the machine executor does not have a gpu. However, conda-forge seems to be handling that quite well - installing the cpu version of pytorch only. This should also help with the time it takes to create the environment as the package is < 100 MB. So, I have removed pytorch channel from dev-requirements.yml.


After these fixes are applied, atleast in ci, no oom was observed. Also, the time it takes to install dependencies from dev-requirements.yml is about the same with python=3.8 and 3.9 and 3.10 - about 9 minutes