### PR TITLE
Fixing issues with triggering build-release-push workflow of kipoi-containers repo from this repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,10 +388,10 @@ workflows:
       - productive-deploy-pypi:
           context:
             - sync-kipoi-containers
-          # requires:
-          #   - test-36
-          #   - test-37
-          #   - test
+          requires:
+            - test-36
+            - test-37
+            - test
           filters:
 #            # Trigger only on a tagged commit starting with v.
 #            # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
@@ -399,7 +399,6 @@ workflows:
 #              only: /^v.*/
             branches:
               only:
-                - deploy
                 - master
   kipoi-nightly-test:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,10 +386,12 @@ workflows:
                 - test_deployment_pypi
                 - test_deployment_script
       - productive-deploy-pypi:
-          requires:
-            - test-36
-            - test-37
-            - test
+          context:
+            - sync-kipoi-containers
+          # requires:
+          #   - test-36
+          #   - test-37
+          #   - test
           filters:
 #            # Trigger only on a tagged commit starting with v.
 #            # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,19 +335,18 @@ jobs:
       - *build_pypi_package
       - *conda_install_twine
       - *pypi_create_pypirc
-      - run:
-          name: check if commit is tagged
-          command: git describe --exact-match --tags HEAD && echo "commit is tagged; continuing" || circleci step halt
-      - run:
-          name: upload to PyPI
-          command: twine upload --repository pypi dist/* --verbose
+      # - run:
+      #     name: check if commit is tagged
+      #     command: git describe --exact-match --tags HEAD && echo "commit is tagged; continuing" || circleci step halt
+      # - run:
+      #     name: upload to PyPI
+      #     command: twine upload --repository pypi dist/* --verbose
       - run:
           name: pip install from PyPI
           command: |
             source activate kipoi-env
             python -m pip install --user kipoi --verbose
-            python -c "import kipoi; print(kipoi.__version__)"
-          
+            python -c "import kipoi; print(kipoi.__version__)"          
       - run:
           name: Update all containers with new version of kipoi
           command: curl -X POST \
@@ -400,6 +399,7 @@ workflows:
 #              only: /^v.*/
             branches:
               only:
+                - deploy
                 - master
   kipoi-nightly-test:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ jobs:
             python -c "import kipoi; print(kipoi.__version__)"          
       - run:
           name: Update all containers with new version of kipoi
-          command: curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $SYNC_TOKEN" https://api.github.com/repos/kipoi/kipoi-containers/dispatches -d '{"event_type":"updateall"}'
+          command: curl -X POST -H "Accept:application/vnd.github.v3+json" -H "Authorization:token $SYNC_TOKEN" https://api.github.com/repos/kipoi/kipoi-containers/dispatches -d '{"event_type":"updateall"}'
 workflows:
   version: 2.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,9 +349,7 @@ jobs:
             python -c "import kipoi; print(kipoi.__version__)"          
       - run:
           name: Update all containers with new version of kipoi
-          command: curl -X POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token $SYNC_TOKEN" https://api.github.com/repos/kipoi/kipoi-containers/dispatches -d '{"event_type":"updateall"}'
+          command: curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $SYNC_TOKEN" https://api.github.com/repos/kipoi/kipoi-containers/dispatches -d '{"event_type":"updateall"}'
 workflows:
   version: 2.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,12 +335,12 @@ jobs:
       - *build_pypi_package
       - *conda_install_twine
       - *pypi_create_pypirc
-      # - run:
-      #     name: check if commit is tagged
-      #     command: git describe --exact-match --tags HEAD && echo "commit is tagged; continuing" || circleci step halt
-      # - run:
-      #     name: upload to PyPI
-      #     command: twine upload --repository pypi dist/* --verbose
+      - run:
+          name: check if commit is tagged
+          command: git describe --exact-match --tags HEAD && echo "commit is tagged; continuing" || circleci step halt
+      - run:
+          name: upload to PyPI
+          command: twine upload --repository pypi dist/* --verbose
       - run:
           name: pip install from PyPI
           command: |


### PR DESCRIPTION
There were two problems
1. Context was missing - SYNC_TOKEN is a context specific environment variable.
2. Github has changed its repository dispatch event url - see [here](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event). Needed to update the CURL statement. However, I somehow could not make circleci parse the yaml with line break.