### PR TITLE
Dataclasses is not needed. Conditional requirement for py3.6 or less

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
     "kipoi-utils>=0.7.5",
     "kipoi-conda>=0.1.6",
     "deprecation>=2.0.6",
-    "dataclasses"
+    "dataclasses; python_version<'3.7'"
 ]
 
 test_requirements = [


### PR DESCRIPTION
Dataclasses is not needed since python 3.7 as it is now part of the stdlid: https://docs.python.org/3/library/dataclasses.html
It also fails for any python greater than 3.6 with : `ERROR: Package 'dataclasses' requires a different Python: 3.8.10 not in '>=3.6, <3.7'`