### PR TITLE
Removing dataclasses from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ requirements = [
     "tinydb",
     "kipoi-utils>=0.7.5",
     "kipoi-conda>=0.1.6",
-    "deprecation>=2.0.6",
-    "dataclasses"
+    "deprecation>=2.0.6"
 ]
 
 test_requirements = [
@@ -48,8 +47,7 @@ test_requirements = [
     "zarr>=2.2.0",  # test_161_writers.py
     # "cyvcf2>=0.10.0",        # test_20_cli_examples.py (and others) (fails on circle-ci)
     "kipoi-interpret>=0.1.2",  # test_42_kipoi_interpret.py
-    "concise>=0.6.6", # Necessary for tests under folder tests/legacy-keras. Does not work for python>=3.8
-    "dataclasses"
+    "concise>=0.6.6" # Necessary for tests under folder tests/legacy-keras. Does not work for python>=3.8
 ]
 
 setup(


### PR DESCRIPTION
Thanks to @[ccoulombe](https://github.com/ccoulombe) and #685 for bringing this to my attention.
It seems dataclasses was an unnecessary dependency. I will shortly release a new version.