### PR TITLE
Fixed kipoi installation

### DIFF
--- a/dev-requirements.yml
+++ b/dev-requirements.yml
@@ -11,7 +11,7 @@ dependencies:
   - pytest-cov>=3.0.0
   - coveralls>=3.3.1
   - tensorflow>=2.8
-  - keras>=2.8
+  - keras>=2.9
   - pyarrow>=8.0
   - zarr>=2.11.3
   - pip>=21.2.4

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ requirements = [
     "tinydb",
     "kipoi-utils>=0.7.5",
     "kipoi-conda>=0.1.6",
-    "deprecation>=2.0.6"
+    "deprecation>=2.0.6",
+    "attrs<=21.4.0"
 ]
 
 test_requirements = [


### PR DESCRIPTION
- attrs recently released a version which drops support for python 2. attrs is used by related which is used by kipoi. Unfortunately related is no longer being maintained. See [here](https://github.com/genomoncology/related/issues/55). I fixed it by pinning attrs to the previous version that worked. 
- Older release of keras (2.8) does not automatically install keras_preprocessing with conda anymore which in turn failed test_10_kipoimodel.py. This has been taken care of in the current release (2.9) - so I upgraded dev-requirements.yml.
