### PR TITLE
Set `zarr` version to 2.12.0

### DIFF
--- a/dev-requirements-py36.yml
+++ b/dev-requirements-py36.yml
@@ -36,7 +36,7 @@ dependencies:
   # for plugins (double check)
   - fastparquet
   - pyarrow
-  - zarr 
+  - zarr=2.8.0
   - numcodecs
   # singularity
   #- singularity

--- a/dev-requirements-py37.yml
+++ b/dev-requirements-py37.yml
@@ -29,7 +29,7 @@ dependencies:
   # for plugins (double check)
   - fastparquet
   - pyarrow=7.0.0
-  - zarr 
+  - zarr=2.12.0
   - numcodecs
   - tinydb>=3.12.2
   # singularity

--- a/dev-requirements.yml
+++ b/dev-requirements.yml
@@ -17,7 +17,7 @@ dependencies:
   - pip>=21.2.4
   - pip:
     - protobuf==3.20
-    - sklearn>=0.0
+    - scikit-learn>=0.0
     - pybedtools>=0.9.0
     - kipoi-interpret
     - kipoiseq


### PR DESCRIPTION
This should fix the issue regarding the failing 3.7 test. The goal here is to use a version of `zarr` that supports 3.7.